### PR TITLE
Server-side data fetching with RLS - token in local.user instead of s…

### DIFF
--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -241,7 +241,7 @@ export const GET: RequestHandler<GetOutput> = async ({ locals }) =>
       user: locals.user
     },
     async () => {
-      const { data } = await supabaseServerClient(session.accessToken)
+      const { data } = await supabaseServerClient(locals.user.accessToken)
       	.from<TestTable>("test")
 	.select("*");
 


### PR DESCRIPTION
Testing the example I can use supabaseServerClient(locals.user.accessToken) successfully. 
But the supabaseServerClient(session.accessToken) does not work for me in the endpoint.