### PR TITLE
SvelteKit `withApiAuth/withPageAuth` nullable `user` arg

### DIFF
--- a/packages/sveltekit/src/utils/withApiAuth.ts
+++ b/packages/sveltekit/src/utils/withApiAuth.ts
@@ -5,7 +5,7 @@ import { isFunction } from './guards';
 interface ApiAuthOpts {
   redirectTo?: string;
   status?: number;
-  user: User;
+  user: User | null;
 }
 
 export default async function withApiAuth<T>(

--- a/packages/sveltekit/src/utils/withPageAuth.ts
+++ b/packages/sveltekit/src/utils/withPageAuth.ts
@@ -5,7 +5,7 @@ import { isFunction } from './guards';
 interface PageAuthOpts {
   redirectTo?: string;
   status?: number;
-  user: User;
+  user: User | null;
 }
 
 /**


### PR DESCRIPTION
It seems like `withApiAuth` and `withPageAuth` are meant to handle cases where the `user` argument is null, so this PR makes them nullable