### PR TITLE
WIP: Ability to redirect user back after login

### DIFF
--- a/packages/nextjs/src/utils/withPageAuth.ts
+++ b/packages/nextjs/src/utils/withPageAuth.ts
@@ -138,7 +138,7 @@ export default function withPageAuth({
       if (authRequired) {
         return {
           redirect: {
-            destination: redirectTo,
+            destination: redirectTo + '?nextUrl=' + context.req.url,
             permanent: false
           }
         };


### PR DESCRIPTION
# Feature request

Ability to redirect user back after login

## Current issue 

Let's take a simple example:

- a unauthenticated user visit a page `/protected` with 

```js
export const getServerSideProps = withPageAuth({ redirectTo: '/login' })
```

- he's then redirected to `/login` page
- but once authenticated he's back to the home page `/`

What I'd like is to redirect him back to the `/protected` page

## Solution I've considered

On my `/login` page I used a hook to redirect the authenticated user to a given page according to a query param

```js
const { user } = useUser() 
const router = useRouter()
const redirectPath = router.query.nextUrl ?? '/'
useEffect(() => {
  if (user) {
    void router.push(redirectPath)
  }
}, [user]) 
```

The missing part is then propagating the `nextUrl` query param.

This would work for me for a static page name:
```js
export const getServerSideProps = withPageAuth({ redirectTo: '/login?nextUrl=/protected' })
```
but it wouldn't even work for a dynamic url since I don't have access to the current request.

## Additional context

Using a query param is a suggestion but it could also use localStorage or anything else.