### PR TITLE
chore(nextjs, typescript): allow passing GetServerSideProps and NextApiHandler response types

### DIFF
--- a/packages/nextjs/src/utils/withApiAuth.ts
+++ b/packages/nextjs/src/utils/withApiAuth.ts
@@ -22,8 +22,8 @@ import getAccessToken from './getAccessToken';
  *
  * @category Server
  */
-export default function withApiAuth(
-  handler: NextApiHandler,
+export default function withApiAuth<ResponseType = any>(
+  handler: NextApiHandler<ResponseType>,
   options: { cookieOptions?: CookieOptions; tokenRefreshMargin?: number } = {}
 ) {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {

--- a/packages/nextjs/src/utils/withPageAuth.ts
+++ b/packages/nextjs/src/utils/withPageAuth.ts
@@ -53,7 +53,7 @@ import logger from './log';
  *
  * @category Server
  */
-export default function withPageAuth({
+export default function withPageAuth<ResponseType = any>({
   authRequired = true,
   redirectTo = '/',
   getServerSideProps = undefined,
@@ -62,7 +62,7 @@ export default function withPageAuth({
 }: {
   authRequired?: boolean;
   redirectTo?: string;
-  getServerSideProps?: GetServerSideProps;
+  getServerSideProps?: GetServerSideProps<ResponseType>;
   cookieOptions?: CookieOptions;
   tokenRefreshMargin?: number;
 } = {}) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore: allows developers to passthrough concrete types for `withApiAuth/withPageHandler` handler

## What is the current behavior?

Currently we aren't enabled to statically type handlers or getServerSideProps functions with specific return type values, which makes typing hard to ensure functional correctness.

## What is the new behavior?

With this change you would be able to pass-through ResponseType for PageHandlers and/or API Handlers.

Small example for `withApiAuth`: 

```ts
export default withApiAuth<{ text: string }>((req, res) => {
  return res.status(404).send({ text: undefined }) // this will fail
})
```

Small example for `withPageAuth`: 

```ts
export default withPageAuth<{ text: string }>({
  async getServerSideProps() {
    return {
      props: {
        text: undefined // this will fail.
      }
    }
  }
})
```
