### PR TITLE
fix: pass domain & path in logout

### DIFF
--- a/.changeset/dirty-swans-warn.md
+++ b/.changeset/dirty-swans-warn.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+allow passing cookie domain and path in handleLogout

--- a/packages/nextjs/src/handlers/logout.ts
+++ b/packages/nextjs/src/handlers/logout.ts
@@ -34,6 +34,8 @@ export default function handleLogout(
     new NextResponseAdapter(res),
     ['access-token', 'refresh-token', 'provider-token'].map((key) => ({
       name: `${cookieOptions.name}-${key}`,
+      domain: cookieOptions.domain,
+      path: cookieOptions.path,
       value: '',
       maxAge: -1
     }))


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allows one to pass the domain and path in handleLogout to clear the cookies. This is particularly useful if you intend to clear all cookies related to a base domain.
* Note: This is just a patch for the version in `main` - we don't need to handle this in `next` since the logout route is removed