### PR TITLE
ignore non-POST requests

### DIFF
--- a/packages/sveltekit/src/server/handlers/callback.ts
+++ b/packages/sveltekit/src/server/handlers/callback.ts
@@ -48,17 +48,13 @@ export function callback(): Handle {
   const endpointPath = `${endpointPrefix}/callback`;
 
   return async ({ resolve, event }) => {
-    if (event.url.pathname !== endpointPath) {
-      return resolve(event);
+    if (
+      event.url.pathname === endpointPath &&
+      event.request.method === 'POST'
+    ) {
+      return handleCallbackSession(event);
     }
 
-    if (event.request.method !== 'POST') {
-      const headers = new Headers({
-        Allow: 'POST'
-      });
-      return new Response('Method Not Allowed', { headers, status: 405 });
-    }
-
-    return handleCallbackSession(event);
+    return resolve(event);
   };
 }


### PR DESCRIPTION
Fixes #216 

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`/api/auth/callback` catches non-POST methods

## What is the new behavior?

non-POST methods are ignored

## Additional context

We don´t need to check for the method, sveltekit emits a 405 status on its own.
