### PR TITLE
Fix: authListener unsubscribe function

### DIFF
--- a/packages/react/src/components/UserProvider.tsx
+++ b/packages/react/src/components/UserProvider.tsx
@@ -152,7 +152,7 @@ export const UserProvider = (props: Props) => {
 
     return () => {
       window?.removeEventListener('visibilitychange', handleVisibilityChange);
-      authListener?.unsubscribe();
+      authListener?.subscription.unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Fixed the code to unsubscribe the authListener properly using subscripton property.

authListener?.subscription.unsubscribe();

##What kind of change does this PR introduce?
Bug fix

##  What is the current behavior?
```
return () => {
      window?.removeEventListener('visibilitychange', handleVisibilityChange);
      authListener?.unsubscribe();
    };
```
The authListener does not unsubscribe properly.

## What is the new behavior?
```
return () => {
      window?.removeEventListener('visibilitychange', handleVisibilityChange);
      authListener?.subscription.unsubscribe();
    };
```
The authListener unsubscribes properly without errors.

## Additional context
Created an issue earlier #281