### PR TITLE
fix: type useSupabaseClient

### DIFF
--- a/.changeset/many-weeks-rush.md
+++ b/.changeset/many-weeks-rush.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-react': patch
+---
+
+fix: typing for useSupabaseClient.

--- a/examples/nextjs/db_types.ts
+++ b/examples/nextjs/db_types.ts
@@ -1,0 +1,118 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      partners: {
+        Row: {
+          id: number;
+          slug: string;
+          type: Database['public']['Enums']['partner_type'];
+          category: string;
+          developer: string;
+          title: string;
+          description: string;
+          logo: string;
+          images: string[];
+          video: string;
+          overview: string;
+          website: string;
+          docs: string;
+          approved: boolean;
+        };
+        Insert: {
+          id?: number;
+          slug?: string;
+          type?: Database['public']['Enums']['partner_type'];
+          category?: string;
+          developer?: string;
+          title?: string;
+          description?: string;
+          logo?: string;
+          images?: string[];
+          video?: string;
+          overview?: string;
+          website?: string;
+          docs?: string;
+          approved?: boolean;
+        };
+        Update: {
+          id?: number;
+          slug?: string;
+          type?: Database['public']['Enums']['partner_type'];
+          category?: string;
+          developer?: string;
+          title?: string;
+          description?: string;
+          logo?: string;
+          images?: string[];
+          video?: string;
+          overview?: string;
+          website?: string;
+          docs?: string;
+          approved?: boolean;
+        };
+      };
+      partner_contacts: {
+        Row: {
+          id: number;
+          type: Database['public']['Enums']['partner_type'];
+          company: string;
+          country: string;
+          details?: string;
+          email: string;
+          first: string;
+          last: string;
+          phone?: string;
+          size?: number;
+          title?: string;
+          website: string;
+        };
+        Insert: {
+          id?: number;
+          type?: Database['public']['Enums']['partner_type'];
+          company?: string;
+          country?: string;
+          details?: string;
+          email?: string;
+          first?: string;
+          last?: string;
+          phone?: string;
+          size?: number;
+          title?: string;
+          website?: string;
+        };
+        Update: {
+          id?: number;
+          type?: Database['public']['Enums']['partner_type'];
+          company?: string;
+          country?: string;
+          details?: string;
+          email?: string;
+          first?: string;
+          last?: string;
+          phone?: string;
+          size?: number;
+          title?: string;
+          website?: string;
+        };
+      };
+    };
+    Views: {};
+    Functions: {
+      derive_label_sort_from_label: {
+        Args: { label: string };
+        Returns: string;
+      };
+    };
+    Enums: {
+      partner_type: 'technology' | 'expert';
+    };
+  };
+}

--- a/examples/nextjs/pages/_app.tsx
+++ b/examples/nextjs/pages/_app.tsx
@@ -3,11 +3,14 @@ import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
+import { Database } from '../db_types';
 import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
-  const [supabaseClient] = useState(() => createBrowserSupabaseClient());
+  const [supabaseClient] = useState(() =>
+    createBrowserSupabaseClient<Database>()
+  );
 
   return (
     <SessionContextProvider

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -1,11 +1,16 @@
-import { useSessionContext } from '@supabase/auth-helpers-react';
+import {
+  useSessionContext,
+  useSupabaseClient
+} from '@supabase/auth-helpers-react';
 import { Auth, ThemeSupa } from '@supabase/auth-ui-react';
 import type { NextPage } from 'next';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { Database } from '../db_types';
 
 const LoginPage: NextPage = () => {
-  const { isLoading, session, error, supabaseClient } = useSessionContext();
+  const { isLoading, session, error } = useSessionContext();
+  const supabaseClient = useSupabaseClient<Database>();
 
   const [data, setData] = useState(null);
 

--- a/packages/nextjs/MIGRATION_GUIDE.md
+++ b/packages/nextjs/MIGRATION_GUIDE.md
@@ -36,9 +36,28 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 }
 ```
 
-- The `UserProvider` has been replaced by the `SessionContextProvider`. Make sure to wrap your `pages/_app.js` componenent with the `SessionContextProvider`. Then, throughout your application you can use the `useSessionContext` hook to get the `session` as well as an authenticated `supabaseClient`.
+- The `UserProvider` has been replaced by the `SessionContextProvider`. Make sure to wrap your `pages/_app.js` componenent with the `SessionContextProvider`. Then, throughout your application you can use the `useSessionContext` hook to get the `session` and the `useSupabaseClient` hook to get an authenticated `supabaseClient`.
 
 - The `useUser` hook now returns the `user` object or `null`.
+
+- Usage with TypeScript: You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+
+```js
+// Creating a new supabase client object:
+import { Database } from '../db_types';
+
+const [supabaseClient] = useState(() =>
+    createBrowserSupabaseClient<Database>()
+  );
+```
+
+```js
+// Retrieving a supabase client object from the SessionContext:
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+import { Database } from '../db_types';
+
+const supabaseClient = useSupabaseClient<Database>();
+```
 
 ## Migrating from @supabase/supabase-auth-helpers to @supabase/auth-helpers
 

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -77,6 +77,27 @@ function MyApp({ Component, pageProps }: AppProps) {
 
 You can now determine if a user is authenticated by checking that the `user` object returned by the `useUser()` hook is defined.
 
+### Usage with TypeScript
+
+You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+
+```js
+// Creating a new supabase client object:
+import { Database } from '../db_types';
+
+const [supabaseClient] = useState(() =>
+    createBrowserSupabaseClient<Database>()
+  );
+```
+
+```js
+// Retrieving a supabase client object from the SessionContext:
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+import { Database } from '../db_types';
+
+const supabaseClient = useSupabaseClient<Database>();
+```
+
 ## Client-side data fetching with RLS
 
 For [row level security](https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security) to work properly when fetching data client-side, you need to make sure to use the `supabaseClient` from the `useSessionContext` hook and only run your query once the user is defined client-side in the `useUser()` hook:

--- a/packages/react/src/components/SessionContext.tsx
+++ b/packages/react/src/components/SessionContext.tsx
@@ -141,7 +141,12 @@ export const useSessionContext = () => {
   return context;
 };
 
-export const useSupabaseClient = () => {
+export function useSupabaseClient<
+  Database = any,
+  SchemaName extends string & keyof Database = 'public' extends keyof Database
+    ? 'public'
+    : string & keyof Database
+>() {
   const context = useContext(SessionContext);
   if (context === undefined) {
     throw new Error(
@@ -149,8 +154,8 @@ export const useSupabaseClient = () => {
     );
   }
 
-  return context.supabaseClient;
-};
+  return context.supabaseClient as SupabaseClient<Database, SchemaName>;
+}
 
 export const useSession = () => {
   const context = useContext(SessionContext);


### PR DESCRIPTION
Fixes #273 

You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:

```js
// Creating a new supabase client object:
import { Database } from '../db_types';

const [supabaseClient] = useState(() =>
    createBrowserSupabaseClient<Database>()
  );
```

```js
// Retrieving a supabase client object from the SessionContext:
import { useSupabaseClient } from '@supabase/auth-helpers-react';
import { Database } from '../db_types';

const supabaseClient = useSupabaseClient<Database>();
```