### PR TITLE
Fix withPageAuth undefined user error

### DIFF
--- a/packages/nextjs/src/utils/withPageAuth.ts
+++ b/packages/nextjs/src/utils/withPageAuth.ts
@@ -151,7 +151,7 @@ export default function withPageAuth<
         ...ret,
         props: {
           initialSession: session,
-          user: session?.user,
+          user: session?.user ?? null,
           ...ret.props
         }
       };


### PR DESCRIPTION
Fix
```
error - SerializableError: Error serializing `.user` returned from `getServerSideProps` in "/".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```