### PR TITLE
Specify DatabaseDefinitions origins for Sveltekit (Get types working)

### DIFF
--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -119,7 +119,7 @@ This results in less server calls as the client manages the session on it´s own
 
 ### Typings with v2 from Supabase CLI
 
-In order to get the most out of TypeScript and it´s intellisense, you should import our types into the `app.d.ts` type definition file that comes with your SvelteKit project, where `import('./DatabaseDefinitions')` points to the generated types file outlined in [v2 docs here](https://supabase.com/docs/reference/javascript/release-notes#typescript-support) after you have logged in, linked, and generated types through the Supabase CLI.
+In order to get the most out of TypeScript and it´s intellisense, you should import the generated Database types into the `app.d.ts` type definition file that comes with your SvelteKit project, where `import('./DatabaseDefinitions')` points to the generated types file outlined in [v2 docs here](https://supabase.com/docs/reference/javascript/release-notes#typescript-support) after you have logged in, linked, and generated types through the Supabase CLI.
 
 ```ts
 // src/app.d.ts

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -117,9 +117,9 @@ export const load: LayoutLoad = async (event) => {
 
 This results in less server calls as the client manages the session on it´s own.
 
-### Typings
+### Typings with v2 from Supabase CLI
 
-In order to get the most out of TypeScript and it´s intellisense, you should import our types into the `app.d.ts` type definition file that comes with your SvelteKit project.
+In order to get the most out of TypeScript and it´s intellisense, you should import our types into the `app.d.ts` type definition file that comes with your SvelteKit project, where `import('./DatabaseDefinitions')` points to the generated types file outlined in [v2 docs here](https://supabase.com/docs/reference/javascript/release-notes#typescript-support) after you have logged in, linked, and generated types through the Supabase CLI.
 
 ```ts
 // src/app.d.ts


### PR DESCRIPTION
Clarifies confusion about how DatabaseDefinitions was created using Supabase CLI. This clears some potential confusion and clarifies #289, where the user should have the import point to their types file.