### PR TITLE
sveltekit ssr disable auto token refresh

### DIFF
--- a/.changeset/sixty-dolls-tickle.md
+++ b/.changeset/sixty-dolls-tickle.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-sveltekit': patch
+---
+
+sveltekit ssr disable auto token refresh

--- a/packages/sveltekit/src/utils/supabase-load.ts
+++ b/packages/sveltekit/src/utils/supabase-load.ts
@@ -14,6 +14,7 @@ export function getLoadSupabaseClient(event: LoadEvent): TypedSupabaseClient {
   return createClient(supabaseUrl, supabaseKey, {
     ...options,
     auth: {
+      autoRefreshToken: false,
       storage: {
         async getItem(key) {
           let session: Session | null = null;


### PR DESCRIPTION
fixes #343

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The supabase instance created in shared load functions on the server auto refreshes the token

## What is the new behavior?

no auto refresh on the server side