### PR TITLE
chore: reduce cookie size

### DIFF
--- a/.changeset/sour-carrots-own.md
+++ b/.changeset/sour-carrots-own.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-shared': patch
+---
+
+chore: reduce cookie size.

--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+.vscode

--- a/examples/nextjs/pages/_app.tsx
+++ b/examples/nextjs/pages/_app.tsx
@@ -1,13 +1,18 @@
 import { useRouter } from 'next/router';
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import {
+  createBrowserSupabaseClient,
+  Session
+} from '@supabase/auth-helpers-nextjs';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
 import { Database } from '../db_types';
 import '../styles/globals.css';
 
-function MyApp({ Component, pageProps }: AppProps) {
-  console.log('PAGEPROPS:', pageProps, pageProps.initialSession);
+function MyApp({
+  Component,
+  pageProps
+}: AppProps<{ initialSession: Session }>) {
   const router = useRouter();
   const [supabaseClient] = useState(() =>
     createBrowserSupabaseClient<Database>()

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -1,6 +1,7 @@
 import {
   useSessionContext,
-  useSupabaseClient
+  useSupabaseClient,
+  useUser
 } from '@supabase/auth-helpers-react';
 import { Auth, ThemeSupa } from '@supabase/auth-ui-react';
 import type { NextPage } from 'next';
@@ -10,18 +11,19 @@ import { Database } from '../db_types';
 
 const LoginPage: NextPage = () => {
   const { isLoading, session, error } = useSessionContext();
+  const user = useUser();
   const supabaseClient = useSupabaseClient<Database>();
 
   const [data, setData] = useState(null);
 
   useEffect(() => {
     async function loadData() {
-      const { data } = await supabaseClient.from('test').select('*').single();
+      const { data } = await supabaseClient.from('users').select('*').single();
       setData(data);
     }
 
-    loadData();
-  }, [supabaseClient]);
+    if (user) loadData();
+  }, [user, supabaseClient]);
 
   if (!session)
     return (
@@ -39,7 +41,7 @@ const LoginPage: NextPage = () => {
           Login with github
         </button>
         <Auth
-          redirectTo="http://localhost:3000/"
+          redirectTo="http://localhost:3000"
           appearance={{ theme: ThemeSupa }}
           // view="update_password"
           supabaseClient={supabaseClient}
@@ -57,10 +59,13 @@ const LoginPage: NextPage = () => {
         <Link href="/protected-page">supabaseServerClient</Link>] |{' '}
         <button
           onClick={() =>
-            supabaseClient.auth.updateUser({ data: { test5: 'updated' } })
+            supabaseClient.auth.updateUser({ data: { test1: 'updated' } })
           }
         >
-          Update
+          Update user metadata
+        </button>
+        <button onClick={() => supabaseClient.auth.refreshSession()}>
+          Refresh session
         </button>
       </p>
       {isLoading ? <h1>Loading...</h1> : <h1>Loaded!</h1>}

--- a/examples/sveltekit/src/routes/+page.svelte
+++ b/examples/sveltekit/src/routes/+page.svelte
@@ -27,6 +27,16 @@
 	>
 		GitHub with scopes
 	</button>
+	<button
+		on:click={() => {
+			supabaseClient.auth.signInWithOAuth({
+				provider: 'google',
+				options: { scopes: 'https://www.googleapis.com/auth/userinfo.email' }
+			});
+		}}
+	>
+		Google
+	</button>
 {:else}
 	<p>
 		[<a href="/profile">withPageAuth</a>] | [<a href="/protected-page">supabaseServerClient</a>] | [<a

--- a/packages/remix/src/constants.ts
+++ b/packages/remix/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = "@supabase/auth-helpers-remix";
-export const PKG_VERSION = "0.0.0";
+export const PKG_VERSION = "0.1.0";

--- a/packages/shared/src/supabase-browser.ts
+++ b/packages/shared/src/supabase-browser.ts
@@ -49,7 +49,6 @@ export function createBrowserSupabaseClient<
 
           let session: Session = JSON.parse(_value);
           const value = stringifySupabaseSession(session);
-          console.log('set', key, value);
 
           document.cookie = serialize(key, value, {
             domain,

--- a/packages/shared/src/supabase-browser.ts
+++ b/packages/shared/src/supabase-browser.ts
@@ -1,6 +1,7 @@
 import { createClient, Session } from '@supabase/supabase-js';
 import { parse, serialize } from 'cookie';
 import { CookieOptions, SupabaseClientOptions } from './types';
+import { parseSupabaseCookie, stringifySupabaseSession } from './utils/cookies';
 import { isBrowser } from './utils/helpers';
 
 export function createBrowserSupabaseClient<
@@ -37,18 +38,18 @@ export function createBrowserSupabaseClient<
           }
 
           const cookies = parse(document.cookie);
-          return cookies[key] || null;
+          const session = parseSupabaseCookie(cookies[key]);
+
+          return session ? JSON.stringify(session) : null;
         },
         setItem(key: string, _value: string) {
           if (!isBrowser()) {
             return;
           }
 
-          // remove identities from the user as it sometimes can make the cookie too large
-          // TODO: note this in docs
           let session: Session = JSON.parse(_value);
-          delete session.user.identities;
-          const value = JSON.stringify(session);
+          const value = stringifySupabaseSession(session);
+          console.log('set', key, value);
 
           document.cookie = serialize(key, value, {
             domain,

--- a/packages/shared/src/supabase-server.ts
+++ b/packages/shared/src/supabase-server.ts
@@ -53,7 +53,6 @@ export function createServerSupabaseClient<
           return JSON.stringify(currentSession);
         },
         setItem(key: string, _value: string) {
-          // remove identities from the user as it sometimes can make the cookie too large
           let session: Session = JSON.parse(_value);
           const value = stringifySupabaseSession(session);
 

--- a/packages/shared/src/utils/cookies.ts
+++ b/packages/shared/src/utils/cookies.ts
@@ -75,6 +75,13 @@ export function parseSupabaseCookie(
     if (!session) {
       return null;
     }
+    // Support previous cookie which was a stringified session object.
+    if (session.constructor.name === 'Object') {
+      return session;
+    }
+    if (session.constructor.name !== 'Array') {
+      throw new Error(`Unexpected format: ${session.constructor.name}`);
+    }
 
     const [_header, payloadStr, _signature] = session[0].split('.');
     const payload = decodeBase64URL(payloadStr);
@@ -95,6 +102,7 @@ export function parseSupabaseCookie(
       }
     };
   } catch (err) {
+    console.warn('Failed to parse cookie string:', err);
     return null;
   }
 }


### PR DESCRIPTION
Strip down the cookie to only store the tokens and construct the session by decoding the `access_token`.

In a next step we should look into splitting the cookie up into chunks since the `access_token` itself could exceed 4kb.