### PR TITLE
Fix a bug with withPageAuth when a session is null and authRequired is set to false

### DIFF
--- a/.changeset/fifty-dryers-look.md
+++ b/.changeset/fifty-dryers-look.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Fix a bug with withPageAuth when a session is null and authRequired is set to false

--- a/packages/nextjs/src/utils/withPageAuth.ts
+++ b/packages/nextjs/src/utils/withPageAuth.ts
@@ -151,7 +151,7 @@ export default function withPageAuth<
         ...ret,
         props: {
           initialSession: session,
-          user: session?.user,
+          user: session?.user ?? null,
           ...ret.props
         }
       };


### PR DESCRIPTION
Fix a bug with `withPageAuth` when a session is `null` and `authRequired` is set to false.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

I reported this bug on discord: https://discord.com/channels/839993398554656828/1036308519755984986/1036308519755984986


With a code similar to this:

```ts
export const getServerSideProps = withPageAuth<Database>({
    authRequired: false,
    async getServerSideProps(ctx, supabase) {
        try {
            const { id } = ctx.query

            const response = await supabase
                .from('Videos')
                .select(`
                    title,
                    description,
                    likes,
                    dislikes,
                    views,
                    created_at,
                    VideoLikes (
                        type
                    ),
                    Profiles (
                        username,
                        profile_picture_url
                    ),
                    Servers (
                        id,
                        name
                    )
                `)
                .eq('id', id)
                .limit(1)
                .single()

            return {
                props: {
                    video: response.data,
                    userRating: response.data?.VideoLikes && response.data.VideoLikes[0] ? response.data.VideoLikes[0]['type'] : 0
                }
            }
        } catch (error) {
            console.error(error)
            return { notFound: true }
        }
    },
})
```

This error was occurring when there isn't a session.
![image](https://user-images.githubusercontent.com/20361229/199097680-b56ac001-3563-423c-918f-3661e9fea3a7.png)

## What is the new behavior?

No error will occur and the user will be null instead of undefined

## Additional context

This bug was only happening when `authRequired: false` and the session is null, making `user` as undefined instead of null. Next.js wasn't liking that.