### PR TITLE
Environment variables NOT available in static builds

### DIFF
--- a/examples/sveltekit-email-password/src/lib/db.ts
+++ b/examples/sveltekit-email-password/src/lib/db.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/auth-helpers-sveltekit';
-import { env } from '$env/dynamic/public';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
 
 export const supabaseClient = createClient(
-	env.PUBLIC_SUPABASE_URL ?? '',
-	env.PUBLIC_SUPABASE_ANON_KEY ?? ''
+	PUBLIC_SUPABASE_URL ?? '',
+	PUBLIC_SUPABASE_ANON_KEY ?? ''
 );


### PR DESCRIPTION
Prior code means variables are not available when statically built and/or deployed to Netlify or Vercel. 

## What kind of change does this PR introduce?

Fixes `npm run build` error that environment variables are not available.

## What is the current behavior?

“supabaseUrl is required” error message when deploying statically.

## What is the new behavior?

Error is gone, **supabase** works in `dev` and `production`, server-side and client-side as advertised.

## Additional context

Add any other context or screenshots.
