### PR TITLE
adding fix for host missing

### DIFF
--- a/.changeset/tasty-schools-kneel.md
+++ b/.changeset/tasty-schools-kneel.md
@@ -1,5 +1,5 @@
 ---
-'@supabase/auth-helpers-nextjs': minor
+'@supabase/auth-helpers-nextjs': patch
 ---
 
 Added in a fix to read the right request headers

--- a/.changeset/tasty-schools-kneel.md
+++ b/.changeset/tasty-schools-kneel.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': minor
+---
+
+Added in a fix to read the right request headers

--- a/.changeset/tasty-schools-kneel.md
+++ b/.changeset/tasty-schools-kneel.md
@@ -2,4 +2,4 @@
 '@supabase/auth-helpers-nextjs': patch
 ---
 
-Added in a fix to read the right request headers
+fix: "host" request header is not available. #358

--- a/packages/nextjs/src/middleware/withMiddlewareAuth.ts
+++ b/packages/nextjs/src/middleware/withMiddlewareAuth.ts
@@ -71,7 +71,7 @@ export const withMiddlewareAuth =
           res.headers.append(name, newSessionStr);
         },
         getRequestHeader: (key) => {
-          const header = res.headers.get(key) ?? undefined;
+          const header = req.headers.get(key) ?? undefined;
 
           return header;
         },

--- a/packages/nextjs/src/utils/withApiAuth.ts
+++ b/packages/nextjs/src/utils/withApiAuth.ts
@@ -75,7 +75,8 @@ export default function withApiAuth<
           res.setHeader('set-cookie', [...newSetCookies, newSessionStr]);
         },
         getRequestHeader: (key) => {
-          const header = res.getHeader(key);
+          const header = req.headers[key];
+
           if (typeof header === 'number') {
             return String(header);
           }


### PR DESCRIPTION
What kind of change does this PR introduce?

Updates the code to read headers from the request instead of the response. Fixes #358

What is the current behavior?

The headers are read from the response

What is the new behavior?

The headers are read from the request