### PR TITLE
359-session-data-comes-back-encoded

### DIFF
--- a/.changeset/green-cows-play.md
+++ b/.changeset/green-cows-play.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-shared': patch
+---
+
+fix: session data comes back encoded #359

--- a/packages/shared/src/utils/cookies.ts
+++ b/packages/shared/src/utils/cookies.ts
@@ -51,7 +51,13 @@ const decodeBase64URL = (value: string): string => {
     // but if it is not it will throw a ReferenceError in which case we can try to use Buffer
     // replace are here to convert the Base64-URL into Base64 which is what atob supports
     // replace with //g regex acts like replaceAll
-    return atob(value.replace(/[-]/g, '+').replace(/[_]/g, '/'));
+    // map first encodes the string to percent-encoding before being decoded to utf-8
+    return decodeURIComponent(
+      atob(value.replace(/[-]/g, '+').replace(/[_]/g, '/'))
+        .split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
   } catch (e) {
     if (e instanceof ReferenceError) {
       // running on nodejs < 16

--- a/packages/shared/src/utils/cookies.ts
+++ b/packages/shared/src/utils/cookies.ts
@@ -51,7 +51,7 @@ const decodeBase64URL = (value: string): string => {
     // but if it is not it will throw a ReferenceError in which case we can try to use Buffer
     // replace are here to convert the Base64-URL into Base64 which is what atob supports
     // replace with //g regex acts like replaceAll
-    // map first encodes the string to percent-encoding before being decoded
+    // Decoding base64 to UTF8 see https://stackoverflow.com/a/30106551/17622044
     return decodeURIComponent(
       atob(value.replace(/[-]/g, '+').replace(/[_]/g, '/'))
         .split('')

--- a/packages/shared/src/utils/cookies.ts
+++ b/packages/shared/src/utils/cookies.ts
@@ -51,7 +51,7 @@ const decodeBase64URL = (value: string): string => {
     // but if it is not it will throw a ReferenceError in which case we can try to use Buffer
     // replace are here to convert the Base64-URL into Base64 which is what atob supports
     // replace with //g regex acts like replaceAll
-    // map first encodes the string to percent-encoding before being decoded to utf-8
+    // map first encodes the string to percent-encoding before being decoded
     return decodeURIComponent(
       atob(value.replace(/[-]/g, '+').replace(/[_]/g, '/'))
         .split('')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes [the unicode problem](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem) by converting the string to percent-encoding before being decoded

Note: the escape function is obsolete, which is why i went with this fix

## What is the current behavior?

The atob function cannot decode chars outside the latin1 range

## What is the new behavior?
characters outside the latin1 range can be decoded

fixes #359 