### PR TITLE
Fix imports and broken link

### DIFF
--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -50,6 +50,7 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
+import { AppProps } from "next/app";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -79,7 +79,7 @@ You can now determine if a user is authenticated by checking that the `user` obj
 
 ### Usage with TypeScript
 
-You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/guides/api/generating-types) to the Supabase Client to get enhanced type safety and auto completion:
 
 ```tsx
 // Creating a new supabase client object:
@@ -105,13 +105,13 @@ import { Auth, ThemeSupa } from '@supabase/auth-ui-react';
 import {
   useUser,
   useSessionContext,
-  useSupabase
+  useSupabaseClient
 } from '@supabase/auth-helpers-react';
 import { useEffect, useState } from 'react';
 
 const LoginPage = () => {
   const { isLoading, session, error } = useSessionContext();
-  const supabase = useSupabase();
+  const supabase = useSupabaseClient();
   const user = useUser();
   const [data, setData] = useState();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

- current behaviour uses unexported `import { useSupabase } from @supabase/auth-helpers-react`  
- current behaviour redirects to a broken link (https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) 

## What is the new behavior?

- new behaviour uses exported `import { useSupabaseClient } from @supabase/auth-helpers-react`  
- new behaviour redirects to docs link (https://supabase.com/docs/guides/api/generating-types) 

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
