### PR TITLE
Chore: Update next.js server components example

### DIFF
--- a/examples/nextjs-server-components/app/layout.tsx
+++ b/examples/nextjs-server-components/app/layout.tsx
@@ -1,21 +1,25 @@
 import 'server-only';
 
-import { headers, cookies } from 'next/headers';
 import SupabaseListener from '../components/supabase-listener';
+import SupabaseProvider from '../components/supabase-provider';
 import Login from '../components/login';
 import './globals.css';
-import { createServerComponentSupabaseClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '../db_types';
+import { createServerClient } from '../utils/supabase-server';
+
+import type { Database } from '../db_types';
+import type { SupabaseClient } from '@supabase/auth-helpers-nextjs';
+
+export type TypedSupabaseClient = SupabaseClient<Database>;
+
+// do not cache this layout
+export const revalidate = 0;
 
 export default async function RootLayout({
   children
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = createServerComponentSupabaseClient<Database>({
-    headers,
-    cookies
-  });
+  const supabase = createServerClient();
 
   const {
     data: { session }
@@ -29,9 +33,11 @@ export default async function RootLayout({
       */}
       <head />
       <body>
-        <Login />
-        <SupabaseListener accessToken={session?.access_token} />
-        {children}
+        <SupabaseProvider session={session}>
+          <SupabaseListener serverAccessToken={session?.access_token} />
+          <Login />
+          {children}
+        </SupabaseProvider>
       </body>
     </html>
   );

--- a/examples/nextjs-server-components/app/optional-session/page.tsx
+++ b/examples/nextjs-server-components/app/optional-session/page.tsx
@@ -1,19 +1,13 @@
 import 'server-only';
 
-import { headers, cookies } from 'next/headers';
-import { createServerComponentSupabaseClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '../../db_types';
+import { createServerClient } from '../../utils/supabase-server';
 
 // do not cache this page
 export const revalidate = 0;
 
 // this page will display with or without a user session
 export default async function OptionalSession() {
-  const supabase = createServerComponentSupabaseClient<Database>({
-    headers,
-    cookies
-  });
-
+  const supabase = createServerClient();
   const { data } = await supabase.from('posts').select('*');
 
   return <pre>{JSON.stringify({ data }, null, 2)}</pre>;

--- a/examples/nextjs-server-components/app/realtime/new-post.tsx
+++ b/examples/nextjs-server-components/app/realtime/new-post.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useSupabase } from '../../components/supabase-provider';
+
+export default function NewPost() {
+  const { supabase, session } = useSupabase();
+
+  const handleSubmit = async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const target = e.target as typeof e.target & {
+      post: { value: string };
+    };
+    const post = target.post.value;
+
+    await supabase.from('posts').insert({ content: post });
+    // no need to refresh, as we are subscribed to db changes in `./realtime-posts.tsx`
+  };
+
+  return session ? (
+    <>
+      <form onSubmit={handleSubmit}>
+        <input type="text" name="post" />
+        <button>Send</button>
+      </form>
+    </>
+  ) : (
+    <p>Sign in to see posts</p>
+  );
+}

--- a/examples/nextjs-server-components/app/realtime/page.tsx
+++ b/examples/nextjs-server-components/app/realtime/page.tsx
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { createServerClient } from '../../utils/supabase-server';
+import NewPost from './new-post';
 import RealtimePosts from './realtime-posts';
 
 // do not cache this page
@@ -15,5 +16,10 @@ export default async function Realtime() {
   // data can be passed from server components to client components
   // this allows us to fetch the initial posts before rendering the page
   // our <RealtimePosts /> component will then subscribe to new posts client-side
-  return <RealtimePosts serverPosts={data || []} />;
+  return (
+    <>
+      <RealtimePosts serverPosts={data || []} />
+      <NewPost />
+    </>
+  );
 }

--- a/examples/nextjs-server-components/app/realtime/page.tsx
+++ b/examples/nextjs-server-components/app/realtime/page.tsx
@@ -1,9 +1,7 @@
 import 'server-only';
 
-import { headers, cookies } from 'next/headers';
-import { createServerComponentSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import { createServerClient } from '../../utils/supabase-server';
 import RealtimePosts from './realtime-posts';
-import { Database } from '../../db_types';
 
 // do not cache this page
 export const revalidate = 0;
@@ -11,11 +9,7 @@ export const revalidate = 0;
 // this component fetches the current posts server-side
 // and subscribes to new posts client-side
 export default async function Realtime() {
-  const supabase = createServerComponentSupabaseClient<Database>({
-    headers,
-    cookies
-  });
-
+  const supabase = createServerClient();
   const { data } = await supabase.from('posts').select('*');
 
   // data can be passed from server components to client components

--- a/examples/nextjs-server-components/app/realtime/realtime-posts.tsx
+++ b/examples/nextjs-server-components/app/realtime/realtime-posts.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSupabase } from '../../components/supabase-provider';
 
-import { Database } from '../../db_types';
-import supabase from '../../utils/supabase';
+import type { Database } from '../../db_types';
 
 type Post = Database['public']['Tables']['posts']['Row'];
 
@@ -16,6 +16,7 @@ export default function RealtimePosts({
   serverPosts: Post[];
 }) {
   const [posts, setPosts] = useState(serverPosts);
+  const { supabase } = useSupabase();
 
   useEffect(() => {
     // this overwrites `posts` any time the `serverPosts` prop changes
@@ -31,14 +32,14 @@ export default function RealtimePosts({
       .on(
         'postgres_changes',
         { event: 'INSERT', schema: 'public', table: 'posts' },
-        (payload) => setPosts((posts) => [...posts, payload.new as Post])
+        (payload) => setPosts([...posts, payload.new as Post])
       )
       .subscribe();
 
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [serverPosts]);
+  }, [supabase, setPosts, posts]);
 
   return <pre>{JSON.stringify(posts, null, 2)}</pre>;
 }

--- a/examples/nextjs-server-components/app/required-session/page.tsx
+++ b/examples/nextjs-server-components/app/required-session/page.tsx
@@ -1,8 +1,6 @@
 import 'server-only';
 
-import { headers, cookies } from 'next/headers';
-import { createServerComponentSupabaseClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '../../db_types';
+import { createServerClient } from '../../utils/supabase-server';
 
 // do not cache this page
 export const revalidate = 0;
@@ -10,11 +8,7 @@ export const revalidate = 0;
 // the user will be redirected to the landing page if they are not signed in
 // check middleware.tsx to see how this routing rule is set
 export default async function RequiredSession() {
-  const supabase = createServerComponentSupabaseClient<Database>({
-    headers,
-    cookies
-  });
-
+  const supabase = createServerClient();
   const { data } = await supabase.from('posts').select('*');
 
   return <pre>{JSON.stringify({ data }, null, 2)}</pre>;

--- a/examples/nextjs-server-components/components/login.tsx
+++ b/examples/nextjs-server-components/components/login.tsx
@@ -4,7 +4,7 @@ import { useSupabase } from './supabase-provider';
 
 // Supabase auth needs to be triggered client-side
 export default function Login() {
-  const { supabase } = useSupabase();
+  const { supabase, session } = useSupabase();
 
   const handleEmailLogin = async () => {
     const { error } = await supabase.auth.signInWithPassword({
@@ -35,11 +35,15 @@ export default function Login() {
     }
   };
 
-  return (
+  // this `session` is from the root loader - server-side
+  // therefore, it can safely be used to conditionally render
+  // SSR pages without issues with hydration
+  return session ? (
+    <button onClick={handleLogout}>Logout</button>
+  ) : (
     <>
       <button onClick={handleEmailLogin}>Email Login</button>
       <button onClick={handleGitHubLogin}>GitHub Login</button>
-      <button onClick={handleLogout}>Logout</button>
     </>
   );
 }

--- a/examples/nextjs-server-components/components/login.tsx
+++ b/examples/nextjs-server-components/components/login.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import supabase from '../utils/supabase';
+import { useSupabase } from './supabase-provider';
 
 // Supabase auth needs to be triggered client-side
 export default function Login() {
+  const { supabase } = useSupabase();
+
   const handleEmailLogin = async () => {
     const { error } = await supabase.auth.signInWithPassword({
       email: 'jon@supabase.com',

--- a/examples/nextjs-server-components/components/supabase-listener.tsx
+++ b/examples/nextjs-server-components/components/supabase-listener.tsx
@@ -2,29 +2,36 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import supabase from '../utils/supabase';
+import { useSupabase } from './supabase-provider';
 
 // this component handles refreshing server data when the user logs in or out
 // this method avoids the need to pass a session down to child components
 // in order to re-render when the user's session changes
 // #elegant!
 export default function SupabaseListener({
-  accessToken
+  serverAccessToken
 }: {
-  accessToken?: string;
+  serverAccessToken?: string;
 }) {
+  const { supabase } = useSupabase();
   const router = useRouter();
 
   useEffect(() => {
-    supabase.auth.onAuthStateChange((event, session) => {
-      if (session?.access_token !== accessToken) {
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (session?.access_token !== serverAccessToken) {
         // server and client are out of sync
         // reload the page to fetch fresh server data
         // https://beta.nextjs.org/docs/data-fetching/mutating
         router.refresh();
       }
     });
-  }, [accessToken]);
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [serverAccessToken, router, supabase]);
 
   return null;
 }

--- a/examples/nextjs-server-components/components/supabase-provider.tsx
+++ b/examples/nextjs-server-components/components/supabase-provider.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { Session } from '@supabase/auth-helpers-nextjs';
+import { createContext, useContext, useState } from 'react';
+import type { TypedSupabaseClient } from '../app/layout';
+import { createBrowserClient } from '../utils/supabase-browser';
+
+type MaybeSession = Session | null;
+
+type SupabaseContext = {
+  supabase: TypedSupabaseClient;
+  session: MaybeSession;
+};
+
+// @ts-ignore
+const Context = createContext<SupabaseContext>();
+
+export default function SupabaseProvider({
+  children,
+  session
+}: {
+  children: React.ReactNode;
+  session: MaybeSession;
+}) {
+  const [supabase] = useState(() => createBrowserClient());
+
+  return (
+    <Context.Provider value={{ supabase, session }}>
+      <>{children}</>
+    </Context.Provider>
+  );
+}
+
+export const useSupabase = () => useContext(Context);

--- a/examples/nextjs-server-components/db_types.ts
+++ b/examples/nextjs-server-components/db_types.ts
@@ -13,20 +13,20 @@ export interface Database {
         Row: {
           id: string
           created_at: string
-          title: string
-          user_id: string | null
+          content: string
+          user_id: string
         }
         Insert: {
           id?: string
           created_at?: string
-          title: string
-          user_id?: string | null
+          content: string
+          user_id?: string
         }
         Update: {
           id?: string
           created_at?: string
-          title?: string
-          user_id?: string | null
+          content?: string
+          user_id?: string
         }
       }
     }

--- a/examples/nextjs-server-components/utils/supabase-browser.ts
+++ b/examples/nextjs-server-components/utils/supabase-browser.ts
@@ -1,0 +1,5 @@
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "../db_types";
+
+export const createBrowserClient = () =>
+  createBrowserSupabaseClient<Database>();

--- a/examples/nextjs-server-components/utils/supabase-server.ts
+++ b/examples/nextjs-server-components/utils/supabase-server.ts
@@ -1,0 +1,9 @@
+import { headers, cookies } from "next/headers";
+import { createServerComponentSupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "../db_types";
+
+export const createServerClient = () =>
+  createServerComponentSupabaseClient<Database>({
+    headers,
+    cookies,
+  });

--- a/examples/nextjs-server-components/utils/supabase.ts
+++ b/examples/nextjs-server-components/utils/supabase.ts
@@ -1,4 +1,0 @@
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '../db_types';
-
-export default createBrowserSupabaseClient<Database>();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Simplifies the Next.js 13 Server Components example

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

- instantiating server client is cleaner
- more clear separation of client and server
- single supbase instance for client-side (shared through context)
- fix useEffect dependencies
