### PR TITLE
[Breaking] Allow initial responses from supabase to be reused from the server when doing SSR

### DIFF
--- a/.changeset/tidy-ties-sin.md
+++ b/.changeset/tidy-ties-sin.md
@@ -1,0 +1,6 @@
+---
+'@supabase/auth-helpers-sveltekit': minor
+---
+
+[Breaking] Allow initial responses from supabase to be reused from the server when doing SSR
+Enable `TypedSupabaseClient` to be imported directly from `@supabase/auth-helpers-sveltekit`

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ docs/
 
 # svelte kit
 .svelte-kit
+
+# Intellij IDEs
+.idea/

--- a/examples/sveltekit/src/hooks.server.ts
+++ b/examples/sveltekit/src/hooks.server.ts
@@ -1,1 +1,4 @@
 import '$lib/db';
+import { allowSupabaseServerSideRequests } from '@supabase/auth-helpers-sveltekit';
+
+export const handle = allowSupabaseServerSideRequests;

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -55,6 +55,37 @@ To make sure the client is initialized on the server and the client we include t
 import '$lib/db';
 ```
 
+In the `src/hooks.server.js` we also need to whitelist some Supabase headers to prevent them from being stripped out by SvelteKit:
+
+If you don't have a custom `handle` hook, then you can add the following:
+
+```ts
+import { allowSupabaseServerSideRequests } from '@supabase/auth-helpers-sveltekit';
+
+export const handle = allowSupabaseServerSideRequests;
+```
+
+Otherwise, you can add the following to your existing `handle` hook:
+
+```ts
+import { RequiredWhitelistedHeaders } from '@supabase/auth-helpers-sveltekit';
+
+export async function handle({ event, resolve }) {
+  // ... your existing code
+  
+  const response = await resolve(event, {
+    // This is the important bits. 
+    filterSerializedResponseHeaders(name: string, _value: string): boolean {
+      return RequiredWhitelistedHeaders.includes(name);
+    }
+  });
+
+  // ... More of your code
+  
+  return response;
+}
+```
+
 ### Synchronizing the page store
 
 Edit your `+layout.svelte` file and set up the client side.

--- a/packages/sveltekit/src/hooks.server.ts
+++ b/packages/sveltekit/src/hooks.server.ts
@@ -1,0 +1,16 @@
+import type {Handle} from "@sveltejs/kit";
+
+export const RequiredWhitelistedHeaders: ReadonlyArray<string> = [
+    'content-range'
+]
+
+/**
+ * A default implementation of the `handle` hook, in case you don't need to do anything special.
+ */
+export const allowSupabaseServerSideRequests: Handle = function({event, resolve}) {
+    return resolve(event, {
+        filterSerializedResponseHeaders(name: string, _value: string): boolean {
+            return RequiredWhitelistedHeaders.includes(name);
+        }
+    })
+}

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -1,4 +1,5 @@
-export type { ExtendedEvent, Config } from './types';
+export type { ExtendedEvent, Config, TypedSupabaseClient } from './types';
 export { getSupabase } from './utils/getSupabase';
 export { getServerSession } from './utils/getServerSession';
 export { createClient } from './createClient';
+export { allowSupabaseServerSideRequests, RequiredWhitelistedHeaders } from './hooks.server';

--- a/packages/sveltekit/src/utils/supabase-load.ts
+++ b/packages/sveltekit/src/utils/supabase-load.ts
@@ -1,18 +1,18 @@
 import { getConfig } from '../config';
-import { isBrowser } from '@supabase/auth-helpers-shared';
 import { createClient, type Session } from '@supabase/supabase-js';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { TypedSupabaseClient } from '../types';
 
 export function getLoadSupabaseClient(event: LoadEvent): TypedSupabaseClient {
-  const { supabaseUrl, supabaseKey, options, globalInstance } = getConfig();
-
-  if (isBrowser()) {
-    return globalInstance;
-  }
+  const { supabaseUrl, supabaseKey, options } = getConfig();
 
   return createClient(supabaseUrl, supabaseKey, {
     ...options,
+    global: {
+      // Inject the event fetch function as default, but allow overriding
+      fetch: event.fetch,
+      ...options.global,
+    },
     auth: {
       autoRefreshToken: false,
       storage: {

--- a/packages/sveltekit/src/utils/supabase-request.ts
+++ b/packages/sveltekit/src/utils/supabase-request.ts
@@ -29,7 +29,14 @@ export function getRequestSupabaseClient(
     getRequestHeader(name) {
       return request.headers.get(name) ?? undefined;
     },
-    options,
+    options: {
+      ...options,
+      global: {
+        // Inject the event fetch function as default, but allow overriding
+        fetch: event.fetch,
+        ...options.global,
+      }
+    },
     cookieOptions
   });
 


### PR DESCRIPTION
This is basically the SvelteKit version of #396, which is why I have not created a new issue. 

Also, this is the first time I'm doing a PR for this project, so please do point out if some things should be done differently. 

## What kind of change does this PR introduce?

One of SvelteKit's features is that if you use the `fetch` function provided in the load functions, you can avoid fetching data the server just fetched when the client loads.

This is a breaking change, requiring a slight change to the `hooks.server.ts/js` file. Specifically:

> In the `src/hooks.server.js` we also need to whitelist some Supabase headers to prevent them from being stripped out by SvelteKit:
>
> If you don't have a custom `handle` hook, then you can add the following:
> ```ts
import { allowSupabaseServerSideRequests } from '@supabase/auth-helpers-sveltekit';

export const handle = allowSupabaseServerSideRequests;
```
> Otherwise, you can add the following to your existing `handle` hook:
> ```ts
import { RequiredWhitelistedHeaders } from '@supabase/auth-helpers-sveltekit';

export async function handle({ event, resolve }) {
  // ... your existing code

  const response = await resolve(event, {
    // This is the important bits.
    filterSerializedResponseHeaders(name: string, _value: string): boolean {
      return RequiredWhitelistedHeaders.includes(name);
    }
  });

  // ... More of your code

  return response;
}
```

I also fixed #409 to enable `TypedSupabaseClient` to be imported directly from `@supabase/auth-helpers-sveltekit` while I was here.

## What is the current behavior?

Data is loaded twice, first on the server, then on the client on the initial navigation. 

## What is the new behavior?

Data is only loaded once, server side, on the initial load. Afterwards purely client side loading is used. 

