### PR TITLE
Fix getServerSession parameter type

### DIFF
--- a/packages/sveltekit/src/utils/getServerSession.ts
+++ b/packages/sveltekit/src/utils/getServerSession.ts
@@ -1,8 +1,8 @@
-import type { ServerLoadEvent } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
 import { getRequestSupabaseClient } from './supabase-request';
 
 export async function getServerSession(
-  event: ServerLoadEvent,
+  event: RequestEvent,
   expiry_margin = 60
 ) {
   const supabase = getRequestSupabaseClient(event);


### PR DESCRIPTION
"getServerSession" is mainly used inside a "LayoutServerLoad" function (it expose an event typed "ServerLoadEvent"), but the event object is only propagated to "getRequestSupabaseClient" that accept a generic "RequestEvent". It doesn't work if I need to get the server session from an api (see https://kit.svelte.dev/docs/routing#server) that by "RequestHandler" offer only a generic "RequestEvent" insead of an "ServerLoadEvent".

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

getServerSession has incompatible event type if used by apis (see https://kit.svelte.dev/docs/routing#server)

## What is the new behavior?

Only a replacement for a more generic type

## Additional context
