### PR TITLE
removed the old svelte reference

### DIFF
--- a/.changeset/olive-jeans-juggle.md
+++ b/.changeset/olive-jeans-juggle.md
@@ -1,0 +1,5 @@
+---
+'tsconfig': patch
+---
+
+fix: removed old svelte reference from tsconfig

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     { "path": "packages/react" },
     { "path": "packages/nextjs" },
     { "path": "packages/shared" },
-    { "path": "packages/svelte" },
     { "path": "packages/sveltekit" }
   ]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a bug fix, there was a reference to an old svelte path that doesn't exist and that was causing some TypeScript errors.