### PR TITLE
feat: allow passing client options

### DIFF
--- a/.changeset/great-glasses-yell.md
+++ b/.changeset/great-glasses-yell.md
@@ -1,0 +1,8 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+'@supabase/auth-helpers-remix': patch
+'@supabase/auth-helpers-shared': patch
+'@supabase/auth-helpers-sveltekit': patch
+---
+
+allow passing client options

--- a/packages/nextjs/src/constants.ts
+++ b/packages/nextjs/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = "@supabase/auth-helpers-nextjs";
-export const PKG_VERSION = "0.4.4";
+export const PKG_VERSION = "0.5.1";

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,6 +1,6 @@
 import {
   CookieOptions,
-  SupabaseClientOptions,
+  SupabaseClientOptionsWithoutAuth,
   createBrowserSupabaseClient as _createBrowserSupabaseClient,
   createServerSupabaseClient as _createServerSupabaseClient,
   ensureArray,
@@ -34,7 +34,7 @@ export function createBrowserSupabaseClient<
   options,
   cookieOptions
 }: {
-  options?: SupabaseClientOptions<SchemaName>;
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
   cookieOptions?: CookieOptions;
 } = {}) {
   if (
@@ -76,7 +76,7 @@ export function createServerSupabaseClient<
     options,
     cookieOptions
   }: {
-    options?: SupabaseClientOptions<SchemaName>;
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {
@@ -135,7 +135,7 @@ export function createMiddlewareSupabaseClient<
     options,
     cookieOptions
   }: {
-    options?: SupabaseClientOptions<SchemaName>;
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -7,6 +7,7 @@ import {
   serializeCookie,
   parseCookies
 } from '@supabase/auth-helpers-shared';
+import { SupabaseClientOptions } from '@supabase/supabase-js';
 import {
   GetServerSidePropsContext,
   NextApiRequest,
@@ -30,8 +31,10 @@ export function createBrowserSupabaseClient<
     ? 'public'
     : string & keyof Database
 >({
+  options,
   cookieOptions
 }: {
+  options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
   cookieOptions?: CookieOptions;
 } = {}) {
   if (
@@ -46,6 +49,16 @@ export function createBrowserSupabaseClient<
   return _createBrowserSupabaseClient<Database, SchemaName>({
     supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
     supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    options: {
+      ...options,
+      global: {
+        ...options?.global,
+        headers: {
+          ...options?.global?.headers,
+          'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
+        }
+      }
+    },
     cookieOptions
   });
 }
@@ -60,8 +73,10 @@ export function createServerSupabaseClient<
     | GetServerSidePropsContext
     | { req: NextApiRequest; res: NextApiResponse },
   {
+    options,
     cookieOptions
   }: {
+    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {
@@ -96,8 +111,11 @@ export function createServerSupabaseClient<
       context.res.setHeader('set-cookie', [...newSetCookies, newSessionStr]);
     },
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }
@@ -114,8 +132,10 @@ export function createMiddlewareSupabaseClient<
 >(
   context: { req: NextRequest; res: NextResponse },
   {
+    options,
     cookieOptions
   }: {
+    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {
@@ -149,8 +169,11 @@ export function createMiddlewareSupabaseClient<
       return header;
     },
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,5 +1,6 @@
 import {
   CookieOptions,
+  SupabaseClientOptions,
   createBrowserSupabaseClient as _createBrowserSupabaseClient,
   createServerSupabaseClient as _createServerSupabaseClient,
   ensureArray,
@@ -7,7 +8,6 @@ import {
   serializeCookie,
   parseCookies
 } from '@supabase/auth-helpers-shared';
-import { SupabaseClientOptions } from '@supabase/supabase-js';
 import {
   GetServerSidePropsContext,
   NextApiRequest,
@@ -34,7 +34,7 @@ export function createBrowserSupabaseClient<
   options,
   cookieOptions
 }: {
-  options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
+  options?: SupabaseClientOptions<SchemaName>;
   cookieOptions?: CookieOptions;
 } = {}) {
   if (
@@ -76,7 +76,7 @@ export function createServerSupabaseClient<
     options,
     cookieOptions
   }: {
-    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
+    options?: SupabaseClientOptions<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {
@@ -135,7 +135,7 @@ export function createMiddlewareSupabaseClient<
     options,
     cookieOptions
   }: {
-    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
+    options?: SupabaseClientOptions<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {

--- a/packages/remix/src/constants.ts
+++ b/packages/remix/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = "@supabase/auth-helpers-remix";
-export const PKG_VERSION = "0.1.2";
+export const PKG_VERSION = "0.1.3";

--- a/packages/remix/src/utils/createSupabaseClient.ts
+++ b/packages/remix/src/utils/createSupabaseClient.ts
@@ -3,10 +3,11 @@ import {
   createServerSupabaseClient,
   parseCookies,
   serializeCookie,
-  createBrowserSupabaseClient
+  createBrowserSupabaseClient,
+  SupabaseClientOptions
 } from '@supabase/auth-helpers-shared';
 import { PKG_NAME, PKG_VERSION } from '../constants';
-import { SupabaseClient, SupabaseClientOptions } from '@supabase/supabase-js';
+import { SupabaseClient } from '@supabase/supabase-js';
 
 /**
  * ## Authenticated Supabase client
@@ -96,7 +97,7 @@ export function createBrowserClient<
     options,
     cookieOptions
   }: {
-    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
+    options?: SupabaseClientOptions<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ): SupabaseClient<Database, SchemaName> {
@@ -139,7 +140,7 @@ export function createServerClient<
   }: {
     request: Request;
     response: Response;
-    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
+    options?: SupabaseClientOptions<SchemaName>;
     cookieOptions?: CookieOptions;
   }
 ): SupabaseClient<Database, SchemaName> {

--- a/packages/remix/src/utils/createSupabaseClient.ts
+++ b/packages/remix/src/utils/createSupabaseClient.ts
@@ -4,7 +4,7 @@ import {
   parseCookies,
   serializeCookie,
   createBrowserSupabaseClient,
-  SupabaseClientOptions
+  SupabaseClientOptionsWithoutAuth
 } from '@supabase/auth-helpers-shared';
 import { PKG_NAME, PKG_VERSION } from '../constants';
 import { SupabaseClient } from '@supabase/supabase-js';
@@ -97,7 +97,7 @@ export function createBrowserClient<
     options,
     cookieOptions
   }: {
-    options?: SupabaseClientOptions<SchemaName>;
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ): SupabaseClient<Database, SchemaName> {
@@ -140,7 +140,7 @@ export function createServerClient<
   }: {
     request: Request;
     response: Response;
-    options?: SupabaseClientOptions<SchemaName>;
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   }
 ): SupabaseClient<Database, SchemaName> {

--- a/packages/remix/src/utils/createSupabaseClient.ts
+++ b/packages/remix/src/utils/createSupabaseClient.ts
@@ -6,7 +6,7 @@ import {
   createBrowserSupabaseClient
 } from '@supabase/auth-helpers-shared';
 import { PKG_NAME, PKG_VERSION } from '../constants';
-import { SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseClient, SupabaseClientOptions } from '@supabase/supabase-js';
 
 /**
  * ## Authenticated Supabase client
@@ -93,8 +93,10 @@ export function createBrowserClient<
   supabaseUrl: string,
   supabaseKey: string,
   {
+    options,
     cookieOptions
   }: {
+    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
     cookieOptions?: CookieOptions;
   } = {}
 ): SupabaseClient<Database, SchemaName> {
@@ -107,6 +109,16 @@ export function createBrowserClient<
   return createBrowserSupabaseClient<Database, SchemaName>({
     supabaseUrl,
     supabaseKey,
+    options: {
+      ...options,
+      global: {
+        ...options?.global,
+        headers: {
+          ...options?.global?.headers,
+          'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
+        }
+      }
+    },
     cookieOptions
   });
 }
@@ -122,10 +134,12 @@ export function createServerClient<
   {
     request,
     response,
+    options,
     cookieOptions
   }: {
     request: Request;
     response: Response;
+    options?: Omit<SupabaseClientOptions<SchemaName>, 'auth'>;
     cookieOptions?: CookieOptions;
   }
 ): SupabaseClient<Database, SchemaName> {
@@ -158,9 +172,13 @@ export function createServerClient<
       });
       response.headers.set('set-cookie', cookieStr);
     },
+
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }

--- a/packages/shared/src/supabase-browser.ts
+++ b/packages/shared/src/supabase-browser.ts
@@ -1,6 +1,6 @@
 import { createClient, Session } from '@supabase/supabase-js';
 import { parse, serialize } from 'cookie';
-import { CookieOptions, SupabaseClientOptions } from './types';
+import { CookieOptions, SupabaseClientOptionsWithoutAuth } from './types';
 import { parseSupabaseCookie, stringifySupabaseSession } from './utils/cookies';
 import { isBrowser } from './utils/helpers';
 
@@ -24,7 +24,7 @@ export function createBrowserSupabaseClient<
 }: {
   supabaseUrl: string;
   supabaseKey: string;
-  options?: SupabaseClientOptions<SchemaName>;
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
   cookieOptions?: CookieOptions;
 }) {
   return createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {

--- a/packages/shared/src/supabase-server.ts
+++ b/packages/shared/src/supabase-server.ts
@@ -1,6 +1,6 @@
 import { createClient, Session } from '@supabase/supabase-js';
 import type { CookieSerializeOptions } from 'cookie';
-import { CookieOptions, SupabaseClientOptions } from './types';
+import { CookieOptions, SupabaseClientOptionsWithoutAuth } from './types';
 import {
   isSecureEnvironment,
   parseSupabaseCookie,
@@ -37,7 +37,7 @@ export function createServerSupabaseClient<
     options: CookieSerializeOptions
   ) => void;
   getRequestHeader: (name: string) => string | string[] | undefined;
-  options?: SupabaseClientOptions<SchemaName>;
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
   cookieOptions?: CookieOptions;
 }) {
   let currentSession = parseSupabaseCookie(getCookie(name)) ?? null;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -6,7 +6,7 @@ export type CookieOptions = { name?: string } & Pick<
   'domain' | 'secure' | 'path' | 'sameSite' | 'maxAge'
 >;
 
-export type SupabaseClientOptions<T = 'public'> = Omit<
+export type SupabaseClientOptionsWithoutAuth<T = 'public'> = Omit<
   _SupabaseClientOptions<T>,
   'auth'
 >;

--- a/packages/sveltekit/src/constants.ts
+++ b/packages/sveltekit/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = '@supabase/auth-helpers-sveltekit';
-export const PKG_VERSION = '0.8.5';
+export const PKG_VERSION = '0.8.6';

--- a/packages/sveltekit/src/createClient.ts
+++ b/packages/sveltekit/src/createClient.ts
@@ -1,7 +1,7 @@
 import {
   createBrowserSupabaseClient,
   type CookieOptions,
-  type SupabaseClientOptions
+  type SupabaseClientOptionsWithoutAuth
 } from '@supabase/auth-helpers-shared';
 import { setConfig } from './config';
 import { PKG_NAME, PKG_VERSION } from './constants';
@@ -10,10 +10,10 @@ import type { TypedSupabaseClient } from './types';
 export function createClient(
   supabaseUrl: string,
   supabaseKey: string,
-  options?: SupabaseClientOptions<App.Supabase['SchemaName']>,
+  options?: SupabaseClientOptionsWithoutAuth<App.Supabase['SchemaName']>,
   cookieOptions?: CookieOptions
 ) {
-  const opts: SupabaseClientOptions<App.Supabase['SchemaName']> = {
+  options = {
     ...options,
     global: {
       ...options?.global,
@@ -23,11 +23,18 @@ export function createClient(
       }
     }
   };
+  cookieOptions = {
+    name: 'supabase-auth-token',
+    path: '/',
+    sameSite: 'lax',
+    maxAge: 1000 * 60 * 60 * 24 * 365,
+    ...cookieOptions
+  };
 
   const globalInstance: TypedSupabaseClient = createBrowserSupabaseClient({
     supabaseUrl,
     supabaseKey,
-    options: opts,
+    options,
     cookieOptions
   });
 
@@ -35,14 +42,8 @@ export function createClient(
     globalInstance,
     supabaseUrl,
     supabaseKey,
-    options: opts,
-    cookieOptions: {
-      name: 'supabase-auth-token',
-      path: '/',
-      sameSite: 'lax',
-      maxAge: 1000 * 60 * 60 * 24 * 365,
-      ...cookieOptions
-    }
+    options,
+    cookieOptions
   });
 
   return globalInstance;

--- a/packages/sveltekit/src/createClient.ts
+++ b/packages/sveltekit/src/createClient.ts
@@ -1,8 +1,7 @@
-import type { SupabaseClientOptions } from '@supabase/supabase-js';
 import {
   createBrowserSupabaseClient,
   type CookieOptions,
-  type SupabaseClientOptions as SupabaseClientOptionsWithoutAuth
+  type SupabaseClientOptions
 } from '@supabase/auth-helpers-shared';
 import { setConfig } from './config';
 import { PKG_NAME, PKG_VERSION } from './constants';
@@ -11,7 +10,7 @@ import type { TypedSupabaseClient } from './types';
 export function createClient(
   supabaseUrl: string,
   supabaseKey: string,
-  options?: SupabaseClientOptionsWithoutAuth<App.Supabase['SchemaName']>,
+  options?: SupabaseClientOptions<App.Supabase['SchemaName']>,
   cookieOptions?: CookieOptions
 ) {
   const opts: SupabaseClientOptions<App.Supabase['SchemaName']> = {
@@ -22,9 +21,6 @@ export function createClient(
         ...options?.global?.headers,
         'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
       }
-    },
-    auth: {
-      storageKey: cookieOptions?.name ?? 'supabase-auth-token'
     }
   };
 

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -1,4 +1,3 @@
-export type { ExtendedEvent, Config } from './types';
 export { getSupabase } from './utils/getSupabase';
 export { getServerSession } from './utils/getServerSession';
 export { createClient } from './createClient';

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -1,8 +1,8 @@
-import type { CookieOptions } from '@supabase/auth-helpers-shared';
 import type {
-  SupabaseClient,
-  SupabaseClientOptions
-} from '@supabase/supabase-js';
+  CookieOptions,
+  SupabaseClientOptionsWithoutAuth
+} from '@supabase/auth-helpers-shared';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 export type TypedSupabaseClient = SupabaseClient<
   App.Supabase['Database'],
@@ -13,6 +13,6 @@ export interface Config {
   globalInstance: TypedSupabaseClient;
   supabaseUrl: string;
   supabaseKey: string;
-  options: SupabaseClientOptions<App.Supabase['SchemaName']>;
+  options: SupabaseClientOptionsWithoutAuth<App.Supabase['SchemaName']>;
   cookieOptions: CookieOptions;
 }

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -1,6 +1,5 @@
 import type { CookieOptions } from '@supabase/auth-helpers-shared';
 import type {
-  Session,
   SupabaseClient,
   SupabaseClientOptions
 } from '@supabase/supabase-js';
@@ -9,11 +8,6 @@ export type TypedSupabaseClient = SupabaseClient<
   App.Supabase['Database'],
   App.Supabase['SchemaName']
 >;
-
-export interface ExtendedEvent {
-  session: Session | null;
-  supabaseClient: TypedSupabaseClient;
-}
 
 export interface Config {
   globalInstance: TypedSupabaseClient;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow passing of client options for nextjs and remix https://github.com/supabase/auth-helpers/issues/420

## What is the current behavior?

Client options can´t be passed.

## What is the new behavior?

client options can be passed:

```ts
import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';

const supabaseClient = createBrowserSupabaseClient({
	options: {
		...
	}
});
```

The auth key is omitted as it is set internally by the helper

