### PR TITLE
Allow passing client options

### DIFF
--- a/.changeset/dull-terms-smell.md
+++ b/.changeset/dull-terms-smell.md
@@ -1,0 +1,8 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+'@supabase/auth-helpers-remix': patch
+'@supabase/auth-helpers-shared': patch
+'@supabase/auth-helpers-sveltekit': patch
+---
+
+Allow passing client options

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -5,7 +5,8 @@ import {
   ensureArray,
   filterCookies,
   serializeCookie,
-  parseCookies
+  parseCookies,
+  SupabaseClientOptionsWithoutAuth
 } from '@supabase/auth-helpers-shared';
 import {
   GetServerSidePropsContext,
@@ -30,8 +31,10 @@ export function createBrowserSupabaseClient<
     ? 'public'
     : string & keyof Database
 >({
+  options,
   cookieOptions
 }: {
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
   cookieOptions?: CookieOptions;
 } = {}) {
   if (
@@ -46,6 +49,16 @@ export function createBrowserSupabaseClient<
   return _createBrowserSupabaseClient<Database, SchemaName>({
     supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
     supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    options: {
+      ...options,
+      global: {
+        ...options?.global,
+        headers: {
+          ...options?.global?.headers,
+          'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
+        }
+      }
+    },
     cookieOptions
   });
 }
@@ -60,8 +73,10 @@ export function createServerSupabaseClient<
     | GetServerSidePropsContext
     | { req: NextApiRequest; res: NextApiResponse },
   {
+    options,
     cookieOptions
   }: {
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {
@@ -96,8 +111,11 @@ export function createServerSupabaseClient<
       context.res.setHeader('set-cookie', [...newSetCookies, newSessionStr]);
     },
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }
@@ -114,8 +132,10 @@ export function createMiddlewareSupabaseClient<
 >(
   context: { req: NextRequest; res: NextResponse },
   {
+    options,
     cookieOptions
   }: {
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ) {
@@ -150,8 +170,11 @@ export function createMiddlewareSupabaseClient<
       return header;
     },
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }

--- a/packages/remix/src/utils/createSupabaseClient.ts
+++ b/packages/remix/src/utils/createSupabaseClient.ts
@@ -3,7 +3,8 @@ import {
   createServerSupabaseClient,
   parseCookies,
   serializeCookie,
-  createBrowserSupabaseClient
+  createBrowserSupabaseClient,
+  SupabaseClientOptionsWithoutAuth
 } from '@supabase/auth-helpers-shared';
 import { PKG_NAME, PKG_VERSION } from '../constants';
 import { SupabaseClient } from '@supabase/supabase-js';
@@ -93,8 +94,10 @@ export function createBrowserClient<
   supabaseUrl: string,
   supabaseKey: string,
   {
+    options,
     cookieOptions
   }: {
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   } = {}
 ): SupabaseClient<Database, SchemaName> {
@@ -107,6 +110,16 @@ export function createBrowserClient<
   return createBrowserSupabaseClient<Database, SchemaName>({
     supabaseUrl,
     supabaseKey,
+    options: {
+      ...options,
+      global: {
+        ...options?.global,
+        headers: {
+          ...options?.global?.headers,
+          'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
+        }
+      }
+    },
     cookieOptions
   });
 }
@@ -122,10 +135,12 @@ export function createServerClient<
   {
     request,
     response,
+    options,
     cookieOptions
   }: {
     request: Request;
     response: Response;
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
     cookieOptions?: CookieOptions;
   }
 ): SupabaseClient<Database, SchemaName> {
@@ -159,8 +174,11 @@ export function createServerClient<
       response.headers.set('set-cookie', cookieStr);
     },
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }

--- a/packages/shared/src/supabase-browser.ts
+++ b/packages/shared/src/supabase-browser.ts
@@ -1,6 +1,6 @@
 import { createClient, Session } from '@supabase/supabase-js';
 import { parse, serialize } from 'cookie';
-import { CookieOptions, SupabaseClientOptions } from './types';
+import { CookieOptions, SupabaseClientOptionsWithoutAuth } from './types';
 import { parseSupabaseCookie, stringifySupabaseSession } from './utils/cookies';
 import { isBrowser } from './utils/helpers';
 
@@ -24,7 +24,7 @@ export function createBrowserSupabaseClient<
 }: {
   supabaseUrl: string;
   supabaseKey: string;
-  options?: SupabaseClientOptions<SchemaName>;
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
   cookieOptions?: CookieOptions;
 }) {
   return createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {

--- a/packages/shared/src/supabase-server.ts
+++ b/packages/shared/src/supabase-server.ts
@@ -1,6 +1,6 @@
 import { createClient, Session } from '@supabase/supabase-js';
 import type { CookieSerializeOptions } from 'cookie';
-import { CookieOptions, SupabaseClientOptions } from './types';
+import { CookieOptions, SupabaseClientOptionsWithoutAuth } from './types';
 import {
   isSecureEnvironment,
   parseSupabaseCookie,
@@ -37,7 +37,7 @@ export function createServerSupabaseClient<
     options: CookieSerializeOptions
   ) => void;
   getRequestHeader: (name: string) => string | string[] | undefined;
-  options?: SupabaseClientOptions<SchemaName>;
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
   cookieOptions?: CookieOptions;
 }) {
   let currentSession = parseSupabaseCookie(getCookie(name)) ?? null;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,12 +1,12 @@
 import type { CookieSerializeOptions } from 'cookie';
-import type { SupabaseClientOptions as _SupabaseClientOptions } from '@supabase/supabase-js';
+import type { SupabaseClientOptions } from '@supabase/supabase-js';
 
 export type CookieOptions = { name?: string } & Pick<
   CookieSerializeOptions,
   'domain' | 'secure' | 'path' | 'sameSite' | 'maxAge'
 >;
 
-export type SupabaseClientOptions<T = 'public'> = Omit<
-  _SupabaseClientOptions<T>,
+export type SupabaseClientOptionsWithoutAuth<T = 'public'> = Omit<
+  SupabaseClientOptions<T>,
   'auth'
 >;

--- a/packages/sveltekit/src/createClient.ts
+++ b/packages/sveltekit/src/createClient.ts
@@ -2,7 +2,7 @@ import type { SupabaseClientOptions } from '@supabase/supabase-js';
 import {
   createBrowserSupabaseClient,
   type CookieOptions,
-  type SupabaseClientOptions as SupabaseClientOptionsWithoutAuth
+  type SupabaseClientOptionsWithoutAuth
 } from '@supabase/auth-helpers-shared';
 import { setConfig } from './config';
 import { PKG_NAME, PKG_VERSION } from './constants';
@@ -22,9 +22,6 @@ export function createClient(
         ...options?.global?.headers,
         'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
       }
-    },
-    auth: {
-      storageKey: cookieOptions?.name ?? 'supabase-auth-token'
     }
   };
 

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -1,4 +1,4 @@
-export type { ExtendedEvent, Config } from './types';
+export type { TypedSupabaseClient } from './types';
 export { getSupabase } from './utils/getSupabase';
 export { getServerSession } from './utils/getServerSession';
 export { createClient } from './createClient';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow passing of client options for nextjs and remix https://github.com/supabase/auth-helpers/issues/420

## What is the current behavior?

Client options can´t be passed.

## What is the new behavior?

client options can be passed:

```ts
import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';

const supabaseClient = createBrowserSupabaseClient({
	options: {
		...
	}
});
```

The auth key is omitted as it is set internally by the helper