### PR TITLE
Allow passing client options in `createServerComponentSupabaseClient`

### DIFF
--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -191,11 +191,13 @@ export function createServerComponentSupabaseClient<
 >({
   headers,
   cookies,
-  cookieOptions
+  cookieOptions,
+  options
 }: {
   headers: () => any; // TODO update this to be ReadonlyRequestCookies when we upgrade to Next.js 13
   cookies: () => any; // TODO update this to be ReadonlyHeaders when we upgrade to Next.js 13
   cookieOptions?: CookieOptions;
+  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
 }) {
   if (
     !process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -223,8 +225,11 @@ export function createServerComponentSupabaseClient<
       // https://beta.nextjs.org/docs/api-reference/cookies
     },
     options: {
+      ...options,
       global: {
+        ...options?.global,
         headers: {
+          ...options?.global?.headers,
           'X-Client-Info': `${PKG_NAME}@${PKG_VERSION}`
         }
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Additional PR for #428, this PR allows passing client options to `createServerComponentSupabaseClient`
