### PR TITLE
[sveltekit] Updated typing to let server api routes call getServerSession

### DIFF
--- a/.changeset/hip-moons-sip.md
+++ b/.changeset/hip-moons-sip.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-sveltekit': patch
+---
+
+Updated typings to allow getServerSession to be called from server api routes

--- a/packages/nextjs/src/constants.ts
+++ b/packages/nextjs/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = "@supabase/auth-helpers-nextjs";
-export const PKG_VERSION = "0.5.2";
+export const PKG_VERSION = "0.5.4";

--- a/packages/remix/src/constants.ts
+++ b/packages/remix/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = "@supabase/auth-helpers-remix";
-export const PKG_VERSION = "0.1.3";
+export const PKG_VERSION = "0.1.4";

--- a/packages/sveltekit/src/constants.ts
+++ b/packages/sveltekit/src/constants.ts
@@ -1,2 +1,2 @@
 export const PKG_NAME = '@supabase/auth-helpers-sveltekit';
-export const PKG_VERSION = '0.8.6';
+export const PKG_VERSION = '0.8.7';

--- a/packages/sveltekit/src/utils/getServerSession.ts
+++ b/packages/sveltekit/src/utils/getServerSession.ts
@@ -1,8 +1,8 @@
-import type { ServerLoadEvent } from '@sveltejs/kit';
+import type { RequestEvent, ServerLoadEvent } from '@sveltejs/kit';
 import { getRequestSupabaseClient } from './supabase-request';
 
 export async function getServerSession(
-  event: ServerLoadEvent,
+  event: RequestEvent | ServerLoadEvent,
   expiry_margin = 60
 ) {
   const supabase = getRequestSupabaseClient(event);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed and updated typing.

## What is the current behavior?

The `getServerSession()` function in `auth-helpers` only accepts events of type `ServerLoadEvent`.
However, [api routes](https://kit.svelte.dev/docs/routing#server) in SvelteKit, which also only run on the server side, require this function as well to validate incoming requests.

But since api routes have an event type of [`RequestEvent`](https://kit.svelte.dev/docs/types#public-types-requestevent) (the parent type of `ServerLoadEvent`), the narrowly-defined auth helper will not allow this.

  
![Screen Shot 2023-02-08 at 1 25 19 PM](https://user-images.githubusercontent.com/113577357/217724371-15c685e6-eb15-4f04-95c6-aa558f364df7.png)


## What is the new behavior?

Allow both server load events and server api routes to call the `getServerSession()` method by updating the typing.

## Additional context

I checked to make sure `RequestEvent` is only used in server-side functions. In addition, client-side request handlers expect the [NavigationEvent](https://kit.svelte.dev/docs/types#public-types-navigationevent) type, so i think we're good to go here.