### PR TITLE
Allow options.auth to be passed into createBrowser/ServerSupabaseClient

### DIFF
--- a/packages/shared/src/supabase-browser.ts
+++ b/packages/shared/src/supabase-browser.ts
@@ -1,6 +1,6 @@
-import { createClient, Session } from '@supabase/supabase-js';
+import { createClient, Session, SupabaseClientOptions } from '@supabase/supabase-js';
 import { parse, serialize } from 'cookie';
-import { CookieOptions, SupabaseClientOptionsWithoutAuth } from './types';
+import { CookieOptions } from './types';
 import { parseSupabaseCookie, stringifySupabaseSession } from './utils/cookies';
 import { isBrowser } from './utils/helpers';
 
@@ -12,7 +12,7 @@ export function createBrowserSupabaseClient<
 >({
   supabaseUrl,
   supabaseKey,
-  options,
+  options: {auth, ...options} = {},
   cookieOptions: {
     name = 'supabase-auth-token',
     domain,
@@ -24,12 +24,13 @@ export function createBrowserSupabaseClient<
 }: {
   supabaseUrl: string;
   supabaseKey: string;
-  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+  options?: SupabaseClientOptions<SchemaName>;
   cookieOptions?: CookieOptions;
 }) {
   return createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
     ...options,
     auth: {
+      ...auth,
       storageKey: name,
       storage: {
         getItem(key: string) {

--- a/packages/shared/src/supabase-server.ts
+++ b/packages/shared/src/supabase-server.ts
@@ -1,6 +1,6 @@
-import { createClient, Session } from '@supabase/supabase-js';
+import { createClient, Session, SupabaseClientOptions } from '@supabase/supabase-js';
 import type { CookieSerializeOptions } from 'cookie';
-import { CookieOptions, SupabaseClientOptionsWithoutAuth } from './types';
+import { CookieOptions } from './types';
 import {
   isSecureEnvironment,
   parseSupabaseCookie,
@@ -18,7 +18,7 @@ export function createServerSupabaseClient<
   getCookie,
   setCookie,
   getRequestHeader,
-  options,
+  options: {auth, ...options} = {},
   cookieOptions: {
     name = 'supabase-auth-token',
     domain,
@@ -37,7 +37,7 @@ export function createServerSupabaseClient<
     options: CookieSerializeOptions
   ) => void;
   getRequestHeader: (name: string) => string | string[] | undefined;
-  options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+  options?: SupabaseClientOptions<SchemaName>;
   cookieOptions?: CookieOptions;
 }) {
   let currentSession = parseSupabaseCookie(getCookie(name)) ?? null;
@@ -45,6 +45,7 @@ export function createServerSupabaseClient<
   return createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
     ...options,
     auth: {
+      ...auth,
       detectSessionInUrl: false,
       autoRefreshToken: false,
       storageKey: name,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -5,8 +5,3 @@ export type CookieOptions = { name?: string } & Pick<
   CookieSerializeOptions,
   'domain' | 'secure' | 'path' | 'sameSite' | 'maxAge'
 >;
-
-export type SupabaseClientOptionsWithoutAuth<T = 'public'> = Omit<
-  SupabaseClientOptions<T>,
-  'auth'
->;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently we cannot pass any auth options when creating supabase client this way. For example `autoRefreshToken` on the client side

## What is the new behavior?

Allow user to specify default options for `auth` while overriding anything we need specifically in the helper. 

## Additional context

Add any other context or screenshots.
