### PR TITLE
Add JSDoc to createClient for clear typing docs

### DIFF
--- a/packages/sveltekit/src/createClient.ts
+++ b/packages/sveltekit/src/createClient.ts
@@ -7,7 +7,11 @@ import {
 import { setConfig } from './config';
 import { PKG_NAME, PKG_VERSION } from './constants';
 import type { TypedSupabaseClient } from './types';
-
+/** 
+ * To get proper typings in the SupabaseClient:
+ *  1. Use the CLI to generate the types: https://supabase.com/docs/guides/database/api/generating-types
+ *  2. Add the types to your app.d.ts file as showin in this guide: https://supabase.com/docs/guides/auth/auth-helpers/sveltekit#typings
+ */
 export function createClient(
   supabaseUrl: string,
   supabaseKey: string,


### PR DESCRIPTION
Hi 👋
First time contributing here, hope it's OK 🙂

I got a little confused when trying to get type generation to work with SvelteKit.    After finding that [at least one other person had the same](#11811) I thought a small PR might be helpful.

**Consideration:** Links might get outdated.

## What kind of change does this PR introduce?

docs: Suggestion to add JSDoc to the `createClient` function.

## What is the current behavior?

No JSDocs

## What is the new behavior?

Some JSDocs

## Additional context
PR for similar fix on the Docs: https://github.com/supabase/supabase/pull/12533  
PR for Discussion Question on same topic: https://github.com/supabase/supabase/discussions/11811