### PR TITLE
Adds MFA factors into session

### DIFF
--- a/.changeset/fresh-scissors-beg.md
+++ b/.changeset/fresh-scissors-beg.md
@@ -4,4 +4,4 @@
 
 Adds MFA factors into session
 
-Factors and identities were removed from session on [PR #350](https://github.com/supabase/auth-helpers/pull/350). When retrieving the `aal` data using ``
+Factors and identities were removed from session on [PR #350](https://github.com/supabase/auth-helpers/pull/350). When retrieving the `aal` data using `getAuthenticatorAssuranceLevel` wrong data is returned

--- a/.changeset/fresh-scissors-beg.md
+++ b/.changeset/fresh-scissors-beg.md
@@ -1,0 +1,7 @@
+---
+'@supabase/auth-helpers-shared': minor
+---
+
+Adds MFA factors into session
+
+Factors and identities were removed from session on [PR #350](https://github.com/supabase/auth-helpers/pull/350). When retrieving the `aal` data using ``

--- a/packages/shared/src/utils/cookies.ts
+++ b/packages/shared/src/utils/cookies.ts
@@ -104,7 +104,8 @@ export function parseSupabaseCookie(
       provider_refresh_token: session[3],
       user: {
         id: sub,
-        ...user
+        factors: session[4],
+        ...user,
       }
     };
   } catch (err) {
@@ -118,6 +119,7 @@ export function stringifySupabaseSession(session: Session): string {
     session.access_token,
     session.refresh_token,
     session.provider_token,
-    session.provider_refresh_token
+    session.provider_refresh_token,
+    session.user.factors,
   ]);
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When calling `stringifySupabaseSession` to build the session string, factors are not added to the list, this makes `getAuthenticatorAssuranceLevel` return the wrong `aal` data because this condition:

```typescript
//  inside getAuthenticatorAssuranceLevel definition
    const verifiedFactors =
      session.user.factors?.filter((factor: Factor) => factor.status === 'verified') ?? []
```

## What is the new behavior?

Factors are added to the session
