### PR TITLE
sveltekit changeset

### DIFF
--- a/.changeset/mean-gifts-hunt.md
+++ b/.changeset/mean-gifts-hunt.md
@@ -1,0 +1,10 @@
+---
+'@supabase/auth-helpers-sveltekit': major
+
+---
+
+SvelteKit rework, 
+ - separate server and client authentication [9bf88f7](https://github.com/supabase/auth-helpers/pull/457/commits/9bf88f76d3124f758394720de84c722052660546)
+ - update supabase-js to 2.7.0 [6a18a94](https://github.com/supabase/auth-helpers/pull/457/commits/6a18a940f4e5ffde022580daf37ba40750637ec1)
+ - update examples [0bef909](https://github.com/supabase/auth-helpers/pull/457/commits/0bef909d912efdf020b24a9d653d2f34080cd107)
+ - use tsup for constants [1da1f67](https://github.com/supabase/auth-helpers/pull/457/commits/1da1f672c020b55103e564137150932b1c122b2c)

--- a/.changeset/mean-gifts-hunt.md
+++ b/.changeset/mean-gifts-hunt.md
@@ -1,9 +1,9 @@
 ---
-'@supabase/auth-helpers-sveltekit': major
+'@supabase/auth-helpers-sveltekit': minor
 
 ---
 
-SvelteKit rework, 
+SvelteKit rework: 
  - separate server and client authentication [9bf88f7](https://github.com/supabase/auth-helpers/pull/457/commits/9bf88f76d3124f758394720de84c722052660546)
  - update supabase-js to 2.7.0 [6a18a94](https://github.com/supabase/auth-helpers/pull/457/commits/6a18a940f4e5ffde022580daf37ba40750637ec1)
  - update examples [0bef909](https://github.com/supabase/auth-helpers/pull/457/commits/0bef909d912efdf020b24a9d653d2f34080cd107)


### PR DESCRIPTION
I was excited to see the sveltekit overhaul merged into main but noticed there was no changeset file to trigger a new release. This is a simple change to resolve that. I noticed the merge includes small changes to other packages but opted to not include them keep the release specific to svelte. Thanks for the work on this!