### PR TITLE
[SvelteKit] Correctly type returned and cached client with generic param

### DIFF
--- a/packages/sveltekit/src/supabaseLoadClient.ts
+++ b/packages/sveltekit/src/supabaseLoadClient.ts
@@ -84,10 +84,10 @@ export function createSupabaseLoadClient<
    * The event listener only runs in the browser.
    */
   onAuthStateChange?: (event: AuthChangeEvent, session: Session | null) => void;
-}) {
+}): SupabaseClient<Database, SchemaName> {
   const browser = isBrowser();
   if (browser && cachedBrowserClient) {
-    return cachedBrowserClient;
+    return cachedBrowserClient as SupabaseClient<Database, SchemaName>;
   }
 
   // this should never happen


### PR DESCRIPTION
## What kind of change does this PR introduce?

TS types bug fix with new SvelteKit client.

## What is the current behavior?

Returned client wasn't correctly narrowing `SchemaName` in `SupabaseClient`.

## What is the new behavior?

Returned type is correctly narrowed with generic parameters

## Additional context

The second change forces the cached client to return with the same type.
