### PR TITLE
Fix #426: set unmount variable when unmounting

### DIFF
--- a/packages/react/src/components/SessionContext.tsx
+++ b/packages/react/src/components/SessionContext.tsx
@@ -78,6 +78,10 @@ export const SessionContextProvider = ({
     }
 
     getSession();
+
+    return () => {
+      mounted = false;
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for issue #426

Previously, the mount variable was always true.