### PR TITLE
Remix example: Check fetcher state to avoid infinite loop

### DIFF
--- a/examples/remix/app/routes/__supabase.tsx
+++ b/examples/remix/app/routes/__supabase.tsx
@@ -56,7 +56,7 @@ export const loader = async ({ request }: LoaderArgs) => {
 
 export default function Supabase() {
   const { env, session } = useLoaderData<typeof loader>();
-  const fetcher = useFetcher();
+  const refreshFetcher = useFetcher();
 
   // it is important to create a single instance of Supabase
   // to use across client components - outlet context 👇
@@ -70,10 +70,10 @@ export default function Supabase() {
     const {
       data: { subscription }
     } = supabase.auth.onAuthStateChange((event, session) => {
-      if (session?.access_token !== serverAccessToken) {
+      if (session?.access_token !== serverAccessToken && refreshFetcher.state === "idle") {
         // server and client are out of sync.
         // Remix recalls active loaders after actions complete
-        fetcher.submit(null, {
+        refreshFetcher.submit(null, {
           method: 'post',
           action: '/handle-supabase-auth'
         });
@@ -83,7 +83,7 @@ export default function Supabase() {
     return () => {
       subscription.unsubscribe();
     };
-  }, [serverAccessToken, supabase, fetcher]);
+  }, [serverAccessToken, supabase, refreshFetcher]);
 
   return (
     <>


### PR DESCRIPTION
In some cases, an auth state change was causing an infinite loop of useEffect. This checks the state of the fetcher before calling submit to make sure it isn't already being submitted.

## What kind of change does this PR introduce?

Bug fix in example

## What is the current behavior?

I didn't see this when running the simple example app, but ran into it with my own app which had no differences in the __supabase.tsx file. When clicking logout or completing login, the browser would freeze because the render was doing an infinite loop of the useEffect.

[Remix #4386](https://github.com/remix-run/remix/pull/4386)

## What is the new behavior?

Infinite loop doesn't occur.

