### PR TITLE
fix: update changeset

### DIFF
--- a/.changeset/curly-dogs-invite.md
+++ b/.changeset/curly-dogs-invite.md
@@ -1,0 +1,9 @@
+---
+'@supabase/auth-helpers-nextjs': minor
+'@supabase/auth-helpers-react': minor
+'@supabase/auth-helpers-remix': minor
+'@supabase/auth-helpers-shared': minor
+'@supabase/auth-helpers-sveltekit': minor
+---
+
+update supabase-js to v2.21.0


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Create a changeset to update the auth-helpers to use the latest supabase-js version - which has an update for using the `plain` code challenge method instead of `s256` in environments which don't support the crypto API