### PR TITLE
Fix Failed to parse cookie string in middleware

### DIFF
--- a/.changeset/brave-lizards-thank.md
+++ b/.changeset/brave-lizards-thank.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Fix "Failed to parse cookie string" bug in middleware storage

--- a/packages/nextjs/src/middlewareClient.ts
+++ b/packages/nextjs/src/middlewareClient.ts
@@ -38,7 +38,6 @@ class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
       httpOnly: false
     });
 
-    this.context.req.headers.append('cookie', newSessionStr);
     this.context.res.headers.set('set-cookie', newSessionStr);
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using the `createMiddlewareSupabaseClient` inside a middleware the storage driver would throw an error due to the cookie being saved twice.

## What is the new behavior?

There is no longer an error and cookie is only saved once.

## Additional context

Add any other context or screenshots.
