### PR TITLE
Chore: Implement naming convention for createClient functions

### DIFF
--- a/.changeset/six-eggs-search.md
+++ b/.changeset/six-eggs-search.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+[BREAKING CHANGES]: Renamed createBrowserSupabaseClient to createPagesBrowserClient, createServerSupabaseClient to createPagesServerClient and createMiddlewareSupabaseClient to createMiddlewareClient

--- a/packages/nextjs/src/clientComponentClient.ts
+++ b/packages/nextjs/src/clientComponentClient.ts
@@ -5,7 +5,7 @@ import {
 	createSupabaseClient
 } from '@supabase/auth-helpers-shared';
 
-export function createBrowserSupabaseClient<
+export function createClientComponentClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'

--- a/packages/nextjs/src/deprecated.ts
+++ b/packages/nextjs/src/deprecated.ts
@@ -1,0 +1,106 @@
+import {
+	SupabaseClientOptionsWithoutAuth,
+	CookieOptionsWithName
+} from '@supabase/auth-helpers-shared';
+import { createPagesBrowserClient } from './pagesBrowserClient';
+import { createPagesServerClient } from './pagesServerClient';
+import { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
+import { NextRequest, NextResponse } from 'next/server';
+import { createMiddlewareClient } from './middlewareClient';
+
+/**
+ * @deprecated utilize the `createPagesBrowserClient` function instead
+ */
+export function createBrowserSupabaseClient<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database
+>({
+	supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+	supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+	options,
+	cookieOptions
+}: {
+	supabaseUrl?: string;
+	supabaseKey?: string;
+	options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+	cookieOptions?: CookieOptionsWithName;
+} = {}) {
+	console.warn(
+		'Please utilize the `createPagesBrowserClient` function instead of the deprecated `createBrowserSupabaseClient` function.'
+	);
+	return createPagesBrowserClient<Database, SchemaName>({
+		supabaseUrl,
+		supabaseKey,
+		options,
+		cookieOptions
+	});
+}
+
+/**
+ * @deprecated utilize the `createPagesServerClient` function instead
+ */
+export function createServerSupabaseClient<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database
+>(
+	context: GetServerSidePropsContext | { req: NextApiRequest; res: NextApiResponse },
+	{
+		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+		options,
+		cookieOptions
+	}: {
+		supabaseUrl?: string;
+		supabaseKey?: string;
+		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+		cookieOptions?: CookieOptionsWithName;
+	} = {}
+) {
+	console.warn(
+		'Please utilize the `createPagesServerClient` function instead of the deprecated `createServerSupabaseClient` function.'
+	);
+	return createPagesServerClient<Database, SchemaName>(context, {
+		supabaseUrl,
+		supabaseKey,
+		options,
+		cookieOptions
+	});
+}
+
+/**
+ * @deprecated utilize the `createMiddlewareClient` function instead
+ */
+export function createMiddlewareSupabaseClient<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database
+>(
+	context: { req: NextRequest; res: NextResponse },
+	{
+		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+		options,
+		cookieOptions
+	}: {
+		supabaseUrl?: string;
+		supabaseKey?: string;
+		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+		cookieOptions?: CookieOptionsWithName;
+	} = {}
+) {
+	console.warn(
+		'Please utilize the `createMiddlewareClient function instead of the deprecated `createMiddlewareSupabaseClient` function.'
+	);
+
+	return createMiddlewareClient<Database, SchemaName>(context, {
+		supabaseUrl,
+		supabaseKey,
+		options,
+		cookieOptions
+	});
+}

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -9,9 +9,10 @@ export type WritableRequestCookies = ReadonlyRequestCookies & {
 	set: (name: string, value: string, options?: CookieOptions) => void;
 };
 
-export { createBrowserSupabaseClient } from './browserClient';
-export { createServerSupabaseClient } from './serverClient';
-export { createMiddlewareSupabaseClient } from './middlewareClient';
-export { createServerComponentSupabaseClient } from './serverComponentClient';
-export { createRouteHandlerSupabaseClient } from './routeHandlerClient';
-export { createServerActionSupabaseClient } from './serverActionClient';
+export { createPagesBrowserClient } from './pagesBrowserClient';
+export { createPagesServerClient } from './pagesServerClient';
+export { createMiddlewareClient } from './middlewareClient';
+export { createClientComponentClient } from './clientComponentClient';
+export { createServerComponentClient } from './serverComponentClient';
+export { createRouteHandlerClient } from './routeHandlerClient';
+export { createServerActionClient } from './serverActionClient';

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -16,3 +16,10 @@ export { createClientComponentClient } from './clientComponentClient';
 export { createServerComponentClient } from './serverComponentClient';
 export { createRouteHandlerClient } from './routeHandlerClient';
 export { createServerActionClient } from './serverActionClient';
+
+// Deprecated Functions
+export {
+	createBrowserSupabaseClient,
+	createServerSupabaseClient,
+	createMiddlewareSupabaseClient
+} from './deprecated';

--- a/packages/nextjs/src/middlewareClient.ts
+++ b/packages/nextjs/src/middlewareClient.ts
@@ -53,7 +53,7 @@ class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
 	}
 }
 
-export function createMiddlewareSupabaseClient<
+export function createMiddlewareClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'

--- a/packages/nextjs/src/pagesBrowserClient.ts
+++ b/packages/nextjs/src/pagesBrowserClient.ts
@@ -1,0 +1,3 @@
+import { createClientComponentClient } from './clientComponentClient';
+
+export const createPagesBrowserClient = createClientComponentClient;

--- a/packages/nextjs/src/pagesServerClient.ts
+++ b/packages/nextjs/src/pagesServerClient.ts
@@ -53,7 +53,7 @@ class NextServerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	}
 }
 
-export function createServerSupabaseClient<
+export function createPagesServerClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'

--- a/packages/nextjs/src/routeHandlerClient.ts
+++ b/packages/nextjs/src/routeHandlerClient.ts
@@ -35,7 +35,7 @@ class NextRouteHandlerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	}
 }
 
-export function createRouteHandlerSupabaseClient<
+export function createRouteHandlerClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'

--- a/packages/nextjs/src/serverActionClient.ts
+++ b/packages/nextjs/src/serverActionClient.ts
@@ -1,3 +1,3 @@
-import { createRouteHandlerSupabaseClient } from './routeHandlerClient';
+import { createRouteHandlerClient } from './routeHandlerClient';
 
-export const createServerActionSupabaseClient = createRouteHandlerSupabaseClient;
+export const createServerActionClient = createRouteHandlerClient;

--- a/packages/nextjs/src/serverComponentClient.ts
+++ b/packages/nextjs/src/serverComponentClient.ts
@@ -34,9 +34,7 @@ class NextServerComponentAuthStorageAdapter extends CookieAuthStorageAdapter {
 	}
 }
 
-export const createRouteHandlerSupabaseClient = createServerComponentSupabaseClient;
-
-export function createServerComponentSupabaseClient<
+export function createServerComponentClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the current behavior?

1. createClient functions do not follow a clear convention
2. pages directory createClient functions are the default - no longer the recommended path

## What is the new behavior?

The App Router createClient functions follow a contextual convention as to where they are being used:

- createClientComponentClient
- createServerComponentClient
- createMiddlewareClient
- createRouteHandlerClient
- createServerActionClient

Pages directory createClient functions now contain `pages` in their name

- createPagesBrowserClient
- createPagesServerClient

---

Have also removed the `Supabase` part of each export, as this feels unnecessary.

## Additional context

We cannot consolidate all server-side functions into a single createServerClient function, as Server Components will not be able to `set` cookies, therefore, will always need to use middleware to refresh expired sessions: https://github.com/vercel/next.js/discussions/41745#discussioncomment-5198848

While `createRouteHandlerClient` and `createServerActionClient` are exactly the same function, I think it best to keep these as separate exports to simplify the DX when consuming them - if they were named the same, I think it would cause more confusion and require an unnecessarily deep understanding of the design decisions of the Next.js App Router.

This same justification goes for `createPagesBrowserClient` and `createClientComponentClient`. Having this clear separation between `pages` and `App Router` simplifies the DX.