### PR TITLE
Fix: Set response cookie

### DIFF
--- a/.changeset/many-avocados-fetch.md
+++ b/.changeset/many-avocados-fetch.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Set cookie header to make new session from middleware available to server component

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,27 +1,27 @@
 {
-  "mode": "pre",
-  "tag": "next",
-  "initialVersions": {
-    "@example/nextjs": "0.0.0",
-    "@example/nextjs-server-components": "0.0.0",
-    "@example/sveltekit": "0.0.0",
-    "config": "0.1.0",
-    "@supabase/auth-helpers-nextjs": "0.6.0",
-    "@supabase/auth-helpers-react": "0.3.1",
-    "@supabase/auth-helpers-remix": "0.1.8",
-    "@supabase/auth-helpers-shared": "0.3.3",
-    "@supabase/auth-helpers-sveltekit": "0.9.3",
-    "tsconfig": "0.1.1"
-  },
-  "changesets": [
-    "brave-lizards-thank",
-    "cyan-dancers-care",
-    "eighty-chefs-protect",
-    "eleven-radios-share",
-    "lazy-cows-shake",
-    "plenty-seas-build",
-    "silly-beds-watch",
-    "six-eggs-search",
-    "violet-frogs-know"
-  ]
+	"mode": "pre",
+	"tag": "next",
+	"initialVersions": {
+		"@example/nextjs": "0.0.0",
+		"@example/nextjs-server-components": "0.0.0",
+		"@example/sveltekit": "0.0.0",
+		"config": "0.1.0",
+		"@supabase/auth-helpers-nextjs": "0.6.0",
+		"@supabase/auth-helpers-react": "0.3.1",
+		"@supabase/auth-helpers-remix": "0.1.8",
+		"@supabase/auth-helpers-shared": "0.3.3",
+		"@supabase/auth-helpers-sveltekit": "0.9.3",
+		"tsconfig": "0.1.1"
+	},
+	"changesets": [
+		"brave-lizards-thank",
+		"cyan-dancers-care",
+		"eighty-chefs-protect",
+		"eleven-radios-share",
+		"lazy-cows-shake",
+		"plenty-seas-build",
+		"silly-beds-watch",
+		"six-eggs-search",
+		"violet-frogs-know"
+	]
 }

--- a/packages/nextjs/src/middlewareClient.ts
+++ b/packages/nextjs/src/middlewareClient.ts
@@ -49,8 +49,10 @@ class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
 			httpOnly: false
 		});
 
-		this.context.res.headers.append('set-cookie', newSessionStr);
-		this.context.res.headers.append('cookie', newSessionStr);
+		if (this.context.res.headers) {
+			this.context.res.headers.append('set-cookie', newSessionStr);
+			this.context.res.headers.append('cookie', newSessionStr);
+		}
 	}
 }
 

--- a/packages/nextjs/src/middlewareClient.ts
+++ b/packages/nextjs/src/middlewareClient.ts
@@ -50,6 +50,7 @@ class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
 		});
 
 		this.context.res.headers.append('set-cookie', newSessionStr);
+		this.context.res.headers.append('cookie', newSessionStr);
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Middleware only appends a `set-cookie` header, which is not available in the Server Component on the first render.

## What is the new behavior?

Middleware also sets a `cookie` header, which is available immediately in the Server Component
