### PR TITLE
Fix: Typedefs for clientClient functions

### DIFF
--- a/.changeset/curly-stingrays-peel.md
+++ b/.changeset/curly-stingrays-peel.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Fix typedefs and add deprecated functions for App Router createClient functions

--- a/packages/nextjs/src/clientComponentClient.ts
+++ b/packages/nextjs/src/clientComponentClient.ts
@@ -4,15 +4,21 @@ import {
 	SupabaseClientOptionsWithoutAuth,
 	createSupabaseClient
 } from '@supabase/auth-helpers-shared';
-import { SupabaseClient } from '@supabase/supabase-js';
 
-let supabase: SupabaseClient<any, string> | undefined;
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
+
+// can't type this properly as `Database`, `SchemaName` and `Schema` are only available within `createClientComponentClient` function
+let supabase: any;
 
 export function createClientComponentClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >({
 	supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
 	supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
@@ -23,7 +29,7 @@ export function createClientComponentClient<
 	supabaseKey?: string;
 	options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
 	cookieOptions?: CookieOptionsWithName;
-} = {}) {
+} = {}): SupabaseClient<Database, SchemaName, Schema> {
 	if (!supabaseUrl || !supabaseKey) {
 		throw new Error(
 			'either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!'
@@ -32,7 +38,7 @@ export function createClientComponentClient<
 
 	const _supabase =
 		supabase ??
-		createSupabaseClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
+		createSupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, {
 			...options,
 			global: {
 				...options?.global,

--- a/packages/nextjs/src/deprecated.ts
+++ b/packages/nextjs/src/deprecated.ts
@@ -4,9 +4,13 @@ import {
 } from '@supabase/auth-helpers-shared';
 import { createPagesBrowserClient } from './pagesBrowserClient';
 import { createPagesServerClient } from './pagesServerClient';
-import { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createMiddlewareClient } from './middlewareClient';
+import { createClientComponentClient } from './clientComponentClient';
+
+import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
+import type { NextRequest } from 'next/server';
+import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
 
 /**
  * @deprecated utilize the `createPagesBrowserClient` function instead
@@ -15,7 +19,10 @@ export function createBrowserSupabaseClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >({
 	supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
 	supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
@@ -30,7 +37,7 @@ export function createBrowserSupabaseClient<
 	console.warn(
 		'Please utilize the `createPagesBrowserClient` function instead of the deprecated `createBrowserSupabaseClient` function.'
 	);
-	return createPagesBrowserClient<Database, SchemaName>({
+	return createPagesBrowserClient<Database, SchemaName, Schema>({
 		supabaseUrl,
 		supabaseKey,
 		options,
@@ -45,7 +52,10 @@ export function createServerSupabaseClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >(
 	context: GetServerSidePropsContext | { req: NextApiRequest; res: NextApiResponse },
 	{
@@ -63,7 +73,7 @@ export function createServerSupabaseClient<
 	console.warn(
 		'Please utilize the `createPagesServerClient` function instead of the deprecated `createServerSupabaseClient` function.'
 	);
-	return createPagesServerClient<Database, SchemaName>(context, {
+	return createPagesServerClient<Database, SchemaName, Schema>(context, {
 		supabaseUrl,
 		supabaseKey,
 		options,
@@ -78,7 +88,10 @@ export function createMiddlewareSupabaseClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >(
 	context: { req: NextRequest; res: NextResponse },
 	{
@@ -97,7 +110,7 @@ export function createMiddlewareSupabaseClient<
 		'Please utilize the `createMiddlewareClient function instead of the deprecated `createMiddlewareSupabaseClient` function.'
 	);
 
-	return createMiddlewareClient<Database, SchemaName>(context, {
+	return createMiddlewareClient<Database, SchemaName, Schema>(context, {
 		supabaseUrl,
 		supabaseKey,
 		options,

--- a/packages/nextjs/src/deprecated.ts
+++ b/packages/nextjs/src/deprecated.ts
@@ -2,15 +2,20 @@ import {
 	SupabaseClientOptionsWithoutAuth,
 	CookieOptionsWithName
 } from '@supabase/auth-helpers-shared';
+import { NextResponse } from 'next/server';
 import { createPagesBrowserClient } from './pagesBrowserClient';
 import { createPagesServerClient } from './pagesServerClient';
-import { NextResponse } from 'next/server';
 import { createMiddlewareClient } from './middlewareClient';
 import { createClientComponentClient } from './clientComponentClient';
+import { createServerComponentClient } from './serverComponentClient';
+import { createRouteHandlerClient } from './routeHandlerClient';
+import { createServerActionClient } from './serverActionClient';
 
 import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
 import type { NextRequest } from 'next/server';
 import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
+import type { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
+import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 
 /**
  * @deprecated utilize the `createPagesBrowserClient` function instead
@@ -35,7 +40,7 @@ export function createBrowserSupabaseClient<
 	cookieOptions?: CookieOptionsWithName;
 } = {}) {
 	console.warn(
-		'Please utilize the `createPagesBrowserClient` function instead of the deprecated `createBrowserSupabaseClient` function.'
+		'Please utilize the `createPagesBrowserClient` function instead of the deprecated `createBrowserSupabaseClient` function. Learn more: https://supabase.com/docs/guides/auth/auth-helpers/nextjs-pages'
 	);
 	return createPagesBrowserClient<Database, SchemaName, Schema>({
 		supabaseUrl,
@@ -71,7 +76,7 @@ export function createServerSupabaseClient<
 	} = {}
 ) {
 	console.warn(
-		'Please utilize the `createPagesServerClient` function instead of the deprecated `createServerSupabaseClient` function.'
+		'Please utilize the `createPagesServerClient` function instead of the deprecated `createServerSupabaseClient` function. Learn more: https://supabase.com/docs/guides/auth/auth-helpers/nextjs-pages'
 	);
 	return createPagesServerClient<Database, SchemaName, Schema>(context, {
 		supabaseUrl,
@@ -107,7 +112,7 @@ export function createMiddlewareSupabaseClient<
 	} = {}
 ) {
 	console.warn(
-		'Please utilize the `createMiddlewareClient function instead of the deprecated `createMiddlewareSupabaseClient` function.'
+		'Please utilize the `createMiddlewareClient` function instead of the deprecated `createMiddlewareSupabaseClient` function. Learn more: https://supabase.com/docs/guides/auth/auth-helpers/nextjs#middleware'
 	);
 
 	return createMiddlewareClient<Database, SchemaName, Schema>(context, {
@@ -116,4 +121,118 @@ export function createMiddlewareSupabaseClient<
 		options,
 		cookieOptions
 	});
+}
+
+/**
+ * @deprecated utilize the `createClientComponentClient` function instead
+ */
+export function createClientComponentSupabaseClient<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
+>({
+	supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+	supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+	options,
+	cookieOptions
+}: {
+	supabaseUrl?: string;
+	supabaseKey?: string;
+	options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+	cookieOptions?: CookieOptionsWithName;
+} = {}) {
+	console.warn(
+		'Please utilize the `createClientComponentClient` function instead of the deprecated `createClientComponentSupabaseClient` function. Learn more: https://supabase.com/docs/guides/auth/auth-helpers/nextjs#client-component'
+	);
+
+	return createClientComponentClient<Database, SchemaName, Schema>({
+		supabaseUrl,
+		supabaseKey,
+		options,
+		cookieOptions
+	});
+}
+
+/**
+ * @deprecated utilize the `createServerComponentClient` function instead
+ */
+export function createServerComponentSupabaseClient<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
+>(
+	context: { headers: () => ReadonlyHeaders; cookies: () => ReadonlyRequestCookies },
+	{
+		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+		options,
+		cookieOptions
+	}: {
+		supabaseUrl?: string;
+		supabaseKey?: string;
+		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+		cookieOptions?: CookieOptionsWithName;
+	} = {}
+) {
+	console.warn(
+		'Please utilize the `createServerComponentClient` function instead of the deprecated `createServerComponentSupabaseClient` function. Additionally, this function no longer requires the `headers` function as a parameter. Learn more: https://supabase.com/docs/guides/auth/auth-helpers/nextjs#server-component'
+	);
+
+	return createServerComponentClient<Database, SchemaName, Schema>(
+		{ cookies: context.cookies },
+		{
+			supabaseUrl,
+			supabaseKey,
+			options,
+			cookieOptions
+		}
+	);
+}
+
+/**
+ * @deprecated utilize the `createRouteHandlerClient` function instead
+ */
+export function createRouteHandlerSupabaseClient<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
+>(
+	context: { headers: () => ReadonlyHeaders; cookies: () => ReadonlyRequestCookies },
+	{
+		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+		options,
+		cookieOptions
+	}: {
+		supabaseUrl?: string;
+		supabaseKey?: string;
+		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+		cookieOptions?: CookieOptionsWithName;
+	} = {}
+) {
+	console.warn(
+		'Please utilize the `createRouteHandlerClient` function instead of the deprecated `createRouteHandlerSupabaseClient` function. Additionally, this function no longer requires the `headers` function as a parameter. Learn more: https://supabase.com/docs/guides/auth/auth-helpers/nextjs#route-handler'
+	);
+
+	return createRouteHandlerClient<Database, SchemaName, Schema>(
+		{ cookies: context.cookies },
+		{
+			supabaseUrl,
+			supabaseKey,
+			options,
+			cookieOptions
+		}
+	);
 }

--- a/packages/nextjs/src/pagesServerClient.ts
+++ b/packages/nextjs/src/pagesServerClient.ts
@@ -10,6 +10,9 @@ import {
 import { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
 import { splitCookiesString } from 'set-cookie-parser';
 
+import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 class NextServerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	constructor(
 		private readonly context:
@@ -57,7 +60,10 @@ export function createPagesServerClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >(
 	context: GetServerSidePropsContext | { req: NextApiRequest; res: NextApiResponse },
 	{
@@ -71,14 +77,14 @@ export function createPagesServerClient<
 		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
 		cookieOptions?: CookieOptionsWithName;
 	} = {}
-) {
+): SupabaseClient<Database, SchemaName, Schema> {
 	if (!supabaseUrl || !supabaseKey) {
 		throw new Error(
 			'either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!'
 		);
 	}
 
-	return createSupabaseClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
+	return createSupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, {
 		...options,
 		global: {
 			...options?.global,

--- a/packages/nextjs/src/routeHandlerClient.ts
+++ b/packages/nextjs/src/routeHandlerClient.ts
@@ -7,6 +7,8 @@ import {
 } from '@supabase/auth-helpers-shared';
 
 import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
+import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 class NextRouteHandlerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	constructor(
@@ -39,7 +41,10 @@ export function createRouteHandlerClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >(
 	context: {
 		cookies: () => ReadonlyRequestCookies;
@@ -55,14 +60,14 @@ export function createRouteHandlerClient<
 		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
 		cookieOptions?: CookieOptionsWithName;
 	} = {}
-) {
+): SupabaseClient<Database, SchemaName, Schema> {
 	if (!supabaseUrl || !supabaseKey) {
 		throw new Error(
 			'either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!'
 		);
 	}
 
-	return createSupabaseClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
+	return createSupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, {
 		...options,
 		global: {
 			...options?.global,

--- a/packages/nextjs/src/serverComponentClient.ts
+++ b/packages/nextjs/src/serverComponentClient.ts
@@ -6,6 +6,8 @@ import {
 	createSupabaseClient
 } from '@supabase/auth-helpers-shared';
 
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
 import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 
 class NextServerComponentAuthStorageAdapter extends CookieAuthStorageAdapter {
@@ -23,14 +25,12 @@ class NextServerComponentAuthStorageAdapter extends CookieAuthStorageAdapter {
 		return nextCookies.get(name)?.value;
 	}
 	protected setCookie(name: string, value: string): void {
-		// Note: The Next.js team at Vercel is working on adding the ability to
-		// set cookies in addition to the cookies function.
-		// https://beta.nextjs.org/docs/api-reference/cookies
+		// Server Components cannot set cookies. Must use Middleware, Server Action or Route Handler
+		// https://github.com/vercel/next.js/discussions/41745#discussioncomment-5198848
 	}
 	protected deleteCookie(name: string): void {
-		// Note: The Next.js team at Vercel is working on adding the ability to
-		// set cookies in addition to the cookies function.
-		// https://beta.nextjs.org/docs/api-reference/cookies
+		// Server Components cannot set cookies. Must use Middleware, Server Action or Route Handler
+		// https://github.com/vercel/next.js/discussions/41745#discussioncomment-5198848
 	}
 }
 
@@ -38,7 +38,10 @@ export function createServerComponentClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
 		? 'public'
-		: string & keyof Database
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
 >(
 	context: {
 		cookies: () => ReadonlyRequestCookies;
@@ -54,14 +57,14 @@ export function createServerComponentClient<
 		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
 		cookieOptions?: CookieOptionsWithName;
 	} = {}
-) {
+): SupabaseClient<Database, SchemaName, Schema> {
 	if (!supabaseUrl || !supabaseKey) {
 		throw new Error(
 			'either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!'
 		);
 	}
 
-	return createSupabaseClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
+	return createSupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, {
 		...options,
 		global: {
 			...options?.global,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Return types were not being correctly provided from createClient functions

## What is the new behavior?

All createClient functions now return `SupabaseClient<Database, SchemaName, Schema>`

Also added deprecated functions for previous App Router createClient functions so we don't break existing apps! 🧠 
