### PR TITLE
Chore: Extend config options to allow for multiple Supabase clients

### DIFF
--- a/.changeset/unlucky-planes-think.md
+++ b/.changeset/unlucky-planes-think.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Allow user to opt out of singleton pattern for Client Components


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Client Components could not create multiple Supabase clients.

## What is the new behavior?

A new config option for `isSingleton` is exposed on the `createClientComponentClient` function, to allow for multiple Supabase clients.

## Additional context

https://github.com/supabase/auth-helpers/issues/563