### PR TITLE
fix: isBrowser helper function on deno

### DIFF
--- a/.changeset/heavy-elephants-stare.md
+++ b/.changeset/heavy-elephants-stare.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-shared': patch
+---
+
+Fix isBrowser helper function on deno

--- a/packages/shared/src/utils/helpers.ts
+++ b/packages/shared/src/utils/helpers.ts
@@ -1,3 +1,3 @@
 export function isBrowser() {
-	return typeof window !== 'undefined';
+	return typeof window !== 'undefined' && typeof window.document !== 'undefined';
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes a bug when deploying to edge functions on Netlify using SvelteKit. This might also fix some other future bugs.

## What is the current behavior?

Since Netlify Edge Functions run on Deno, `window` is defined. So using `typeof window !== 'undefined'` will actually result true.

## What is the new behavior?

This patch makes the `isBrowser` helper function double check if the current environment is a browser.

## Additional context

Related: https://github.com/sveltejs/kit/issues/9810