### PR TITLE
Fix command to run Sveltekit example

### DIFF
--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -36,5 +36,5 @@ pnpm build:sveltekit
 7. Run the following command from the repository root
 
 ```bash
-pnpm dev --filter=@example/sveltekit-email-password -- --open
+pnpm dev --filter=@example/sveltekit -- --open
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update.

## What is the current behavior?
The  command to run the Sveltekit example is incorrect, resulting in the behavior below:

<details>
<summary>Before</summary>

![image](https://github.com/mdjohns/auth-helpers/assets/13648640/da308f0b-21ad-4161-b8a9-696427a423bc)

</details>

## What is the new behavior?

The command to run the Sveltekit example has been corrected, so the app runs successfully:  

<details>
<summary>After</summary>

![image](https://github.com/mdjohns/auth-helpers/assets/13648640/17bf09e3-3e79-434b-a5bb-251abba4726c)

</details>

## Additional context

Add any other context or screenshots.
