### PR TITLE
Handle initialSession changes in context provider

### DIFF
--- a/.changeset/flat-seas-attack.md
+++ b/.changeset/flat-seas-attack.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-react': patch
+---
+
+fix: Handle initialSession changes in context provider

--- a/packages/react/src/components/SessionContext.tsx
+++ b/packages/react/src/components/SessionContext.tsx
@@ -56,6 +56,12 @@ export const SessionContextProvider = ({
 	const [error, setError] = useState<AuthError>();
 
 	useEffect(() => {
+		if (!session && initialSession) {
+			setSession(initialSession)
+		}
+	}, [session, initialSession]);
+	
+	useEffect(() => {
 		let mounted = true;
 
 		async function getSession() {


### PR DESCRIPTION
Resolves #586

## What kind of change does this PR introduce?

This is a bug/logic fix for how `initialSession` is handled in the `SessionContextProvider`.

## What is the current behavior?

At present, `initialSession` is passed into `useState`, which means that it is discarded after the first render. The issue here is that this is often on a login page where it will likely be `undefined`, meaning any session subsequently created on the server side is discarded.

## What is the new behavior?

I’ve just added a `useEffect` that sets the session state if `initialSession` is available and `session` is not.
