### PR TITLE
feat(sveltekit): Fix export fields in package.json

### DIFF
--- a/.changeset/healthy-clocks-approve.md
+++ b/.changeset/healthy-clocks-approve.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-sveltekit': patch
+---
+
+Fix export fields in package.json

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -3,15 +3,17 @@
 	"version": "0.10.1",
 	"description": "A collection of framework specific Auth utilities for working with Supabase.",
 	"type": "module",
-	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"exports": {
-		"./package.json": "./package.json",
-		".": "./dist/index.js"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
Opened because I accidentally closed #600

## What kind of change does this PR introduce?

- Expands bundler/TS support, corrects https://publint.dev/ warnings

## What is the current behavior?

For @supabase/auth-helpers-sveltekit:
```This entrypoint has types at ./dist/index.d.ts but it is not exported from pkg.exports. Consider adding it to pkg.exports["."].types to be compatible with TypeScript's "moduleResolution": "bundler" compiler option.```

## What is the new behavior?

- Warnings removed by adding `exports["."]["types"]` and `exports["."]["import"]` fields
