### PR TITLE
feat: allow promises in CookieAuthStorageAdapter

### DIFF
--- a/packages/shared/src/cookieAuthStorageAdapter.ts
+++ b/packages/shared/src/cookieAuthStorageAdapter.ts
@@ -14,12 +14,14 @@ export abstract class CookieAuthStorageAdapter implements StorageAdapter {
 		};
 	}
 
-	protected abstract getCookie(name: string): string | undefined | null;
-	protected abstract setCookie(name: string, value: string): void;
+	protected abstract getCookie(
+		name: string
+	): string | undefined | null | Promise<string | undefined | null>;
+	protected abstract setCookie(name: string, value: string): void | Promise<void>;
 	protected abstract deleteCookie(name: string): void;
 
-	getItem(key: string): string | Promise<string | null> | null {
-		const value = this.getCookie(key);
+	async getItem(key: string): Promise<string | null> {
+		const value = await this.getCookie(key);
 
 		if (!value) return null;
 

--- a/packages/shared/src/cookieAuthStorageAdapter.ts
+++ b/packages/shared/src/cookieAuthStorageAdapter.ts
@@ -17,7 +17,7 @@ export abstract class CookieAuthStorageAdapter implements StorageAdapter {
 	protected abstract getCookie(
 		name: string
 	): string | undefined | null | Promise<string | undefined | null>;
-	protected abstract setCookie(name: string, value: string): void | Promise<void>;
+	protected abstract setCookie(name: string, value: string): void;
 	protected abstract deleteCookie(name: string): void;
 
 	async getItem(key: string): Promise<string | null> {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature / chore

## What is the current behavior?

`CookieAuthStorageAdapter` doesn't await the response of `this.getCookie(key)`.
This limits how much it can be extended as methods like `chrome.cookies.getAll` always run asynchronously.

## What is the new behavior?

`getItem` in the `CookieAuthStorageAdapter` is now an async function that `awaits` the result of `this.getCookie(key)`. 
This should not cause any changes in behaviour and is in line with how `getItem` works in the goTrueClient storage adapter.

## Additional context

My personal use case is that I'm making an adapter to use supabase auth in my extension service worker and I prefer extending `CookieAuthStorageAdapter` over `StorageAdapter`. I figured other people trying to extend it will run into the same issue eventually so making a PR. 
