### PR TITLE
Fix: types for next cookies and headers functions

### DIFF
--- a/.changeset/shy-cats-warn.md
+++ b/.changeset/shy-cats-warn.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Fix type for next.js cookies and headers functions

--- a/packages/nextjs/src/deprecated.ts
+++ b/packages/nextjs/src/deprecated.ts
@@ -9,13 +9,11 @@ import { createMiddlewareClient } from './middlewareClient';
 import { createClientComponentClient } from './clientComponentClient';
 import { createServerComponentClient } from './serverComponentClient';
 import { createRouteHandlerClient } from './routeHandlerClient';
-import { createServerActionClient } from './serverActionClient';
+import { headers, cookies } from 'next/headers';
 
 import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
 import type { NextRequest } from 'next/server';
 import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
-import type { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
-import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 
 /**
  * @deprecated utilize the `createPagesBrowserClient` function instead
@@ -169,7 +167,10 @@ export function createServerComponentSupabaseClient<
 		? Database[SchemaName]
 		: any
 >(
-	context: { headers: () => ReadonlyHeaders; cookies: () => ReadonlyRequestCookies },
+	context: {
+		headers: () => ReturnType<typeof headers>;
+		cookies: () => ReturnType<typeof cookies>;
+	},
 	{
 		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
 		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
@@ -209,7 +210,7 @@ export function createRouteHandlerSupabaseClient<
 		? Database[SchemaName]
 		: any
 >(
-	context: { headers: () => ReadonlyHeaders; cookies: () => ReadonlyRequestCookies },
+	context: { headers: () => ReturnType<typeof headers>; cookies: () => ReturnType<typeof cookies> },
 	{
 		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
 		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,

--- a/packages/nextjs/src/routeHandlerClient.ts
+++ b/packages/nextjs/src/routeHandlerClient.ts
@@ -5,15 +5,15 @@ import {
 	SupabaseClientOptionsWithoutAuth,
 	createSupabaseClient
 } from '@supabase/auth-helpers-shared';
+import { cookies } from 'next/headers';
 
-import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 class NextRouteHandlerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	constructor(
 		private readonly context: {
-			cookies: () => ReadonlyRequestCookies;
+			cookies: () => ReturnType<typeof cookies>;
 		},
 		cookieOptions?: CookieOptions
 	) {
@@ -46,7 +46,7 @@ export function createRouteHandlerClient<
 		: any
 >(
 	context: {
-		cookies: () => ReadonlyRequestCookies;
+		cookies: () => ReturnType<typeof cookies>;
 	},
 	{
 		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/packages/nextjs/src/serverComponentClient.ts
+++ b/packages/nextjs/src/serverComponentClient.ts
@@ -5,15 +5,15 @@ import {
 	SupabaseClientOptionsWithoutAuth,
 	createSupabaseClient
 } from '@supabase/auth-helpers-shared';
+import { cookies } from 'next/headers';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
-import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 
 class NextServerComponentAuthStorageAdapter extends CookieAuthStorageAdapter {
 	constructor(
 		private readonly context: {
-			cookies: () => ReadonlyRequestCookies;
+			cookies: () => ReturnType<typeof cookies>;
 		},
 		cookieOptions?: CookieOptions
 	) {
@@ -44,7 +44,7 @@ export function createServerComponentClient<
 		: any
 >(
 	context: {
-		cookies: () => ReadonlyRequestCookies;
+		cookies: () => ReturnType<typeof cookies>;
 	},
 	{
 		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/packages/react/src/components/SessionContext.tsx
+++ b/packages/react/src/components/SessionContext.tsx
@@ -57,10 +57,10 @@ export const SessionContextProvider = ({
 
 	useEffect(() => {
 		if (!session && initialSession) {
-			setSession(initialSession)
+			setSession(initialSession);
 		}
 	}, [session, initialSession]);
-	
+
 	useEffect(() => {
 		let mounted = true;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Types

## What is the current behavior?

Import type from Next.js `dist` folder for `cookies()` and `headers()` functions

## What is the new behavior?

The type is inferred from the return type of the functions
