### PR TITLE
feat: update session when updating user

### DIFF
--- a/packages/react/src/components/SessionContext.tsx
+++ b/packages/react/src/components/SessionContext.tsx
@@ -94,7 +94,7 @@ export const SessionContextProvider = ({
 		const {
 			data: { subscription }
 		} = supabaseClient.auth.onAuthStateChange((event, session) => {
-			if (session && (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED')) {
+			if (session && (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'USER_UPDATED')) {
 				setSession(session);
 			}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature: update a session state from SessionContext of react helper.

## What is the current behavior?

When using `supabase.auth.updateUser` function, session and user from `useSession`, `useUser` hooks is not updated.

## What is the new behavior?

Session and user that provided by `useSession`, `useUser` is updated after calling `supabase.auth.updateUser` function.
