### PR TITLE
Remove max-age option from cookieOptions

### DIFF
--- a/.changeset/few-carrots-mate.md
+++ b/.changeset/few-carrots-mate.md
@@ -1,0 +1,6 @@
+---
+'@supabase/auth-helpers-nextjs': minor
+'@supabase/auth-helpers-shared': minor
+---
+
+Remove max-age option from cookieOptions

--- a/packages/nextjs/src/middlewareClient.ts
+++ b/packages/nextjs/src/middlewareClient.ts
@@ -3,6 +3,7 @@ import {
 	CookieOptions,
 	CookieOptionsWithName,
 	createSupabaseClient,
+	DefaultCookieOptions,
 	parseCookies,
 	serializeCookie,
 	SupabaseClientOptionsWithoutAuth
@@ -45,7 +46,7 @@ class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
 		});
 	}
 
-	private _setCookie(name: string, value: string, options?: CookieOptions) {
+	private _setCookie(name: string, value: string, options?: DefaultCookieOptions) {
 		const newSessionStr = serializeCookie(name, value, {
 			...this.cookieOptions,
 			...options,

--- a/packages/nextjs/src/pagesServerClient.ts
+++ b/packages/nextjs/src/pagesServerClient.ts
@@ -3,6 +3,7 @@ import {
 	CookieOptions,
 	CookieOptionsWithName,
 	createSupabaseClient,
+	DefaultCookieOptions,
 	parseCookies,
 	serializeCookie,
 	SupabaseClientOptionsWithoutAuth
@@ -40,7 +41,7 @@ class NextServerAuthStorageAdapter extends CookieAuthStorageAdapter {
 		});
 	}
 
-	private _setCookie(name: string, value: string, options?: CookieOptions) {
+	private _setCookie(name: string, value: string, options?: DefaultCookieOptions) {
 		const setCookies = splitCookiesString(
 			this.context.res.getHeader('set-cookie')?.toString() ?? ''
 		).filter((c) => !(name in parseCookies(c)));

--- a/packages/shared/src/cookieAuthStorageAdapter.ts
+++ b/packages/shared/src/cookieAuthStorageAdapter.ts
@@ -1,16 +1,17 @@
 import { GoTrueClientOptions, Session } from '@supabase/supabase-js';
 import { DEFAULT_COOKIE_OPTIONS, parseSupabaseCookie, stringifySupabaseSession } from './utils';
-import { CookieOptions } from './types';
+import { CookieOptions, DefaultCookieOptions } from './types';
 
 export interface StorageAdapter extends Exclude<GoTrueClientOptions['storage'], undefined> {}
 
 export abstract class CookieAuthStorageAdapter implements StorageAdapter {
-	protected readonly cookieOptions: CookieOptions;
+	protected readonly cookieOptions: DefaultCookieOptions;
 
 	constructor(cookieOptions?: CookieOptions) {
 		this.cookieOptions = {
 			...DEFAULT_COOKIE_OPTIONS,
-			...cookieOptions
+			...cookieOptions,
+			maxAge: DEFAULT_COOKIE_OPTIONS.maxAge
 		};
 	}
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,7 +1,9 @@
 import type { CookieSerializeOptions } from 'cookie';
 import type { SupabaseClientOptions } from '@supabase/supabase-js';
 
-export type CookieOptions = Pick<
+export type CookieOptions = Pick<CookieSerializeOptions, 'domain' | 'secure' | 'path' | 'sameSite'>;
+
+export type DefaultCookieOptions = Pick<
 	CookieSerializeOptions,
 	'domain' | 'secure' | 'path' | 'sameSite' | 'maxAge'
 >;

--- a/packages/shared/src/utils/constants.ts
+++ b/packages/shared/src/utils/constants.ts
@@ -1,6 +1,6 @@
-import { CookieOptions } from '../types';
+import { DefaultCookieOptions } from '../types';
 
-export const DEFAULT_COOKIE_OPTIONS: CookieOptions = {
+export const DEFAULT_COOKIE_OPTIONS: DefaultCookieOptions = {
 	path: '/',
 	maxAge: 60 * 60 * 24 * 365 * 1000
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing a bug where we allowed the developer to set the cookie max-age, but we are using cookies only as a storage mechanism for the JWT which already has an expiry time. Closes #635 

## What is the current behavior?

This can currently be set by the developer

## What is the new behavior?

This can no longer be set by the developer

## Additional context

Add any other context or screenshots.
