### PR TITLE
Fix #649: Use CookieAuthStorageAdapter to allow cookie parsing/serialization for SupabaseClient for @supabase/ssr

### DIFF
--- a/packages/shared/src/cookieAuthStorageAdapter.ts
+++ b/packages/shared/src/cookieAuthStorageAdapter.ts
@@ -15,12 +15,14 @@ export abstract class CookieAuthStorageAdapter implements StorageAdapter {
 		};
 	}
 
-	protected abstract getCookie(name: string): string | undefined | null;
+	protected abstract getCookie(
+		name: string
+	): string | undefined | null | Promise<string | undefined | null>;
 	protected abstract setCookie(name: string, value: string): void;
 	protected abstract deleteCookie(name: string): void;
 
-	getItem(key: string): string | Promise<string | null> | null {
-		const value = this.getCookie(key);
+	async getItem(key: string): Promise<string | null> {
+		const value = await this.getCookie(key);
 
 		if (!value) return null;
 

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -34,7 +34,8 @@
 	"homepage": "https://github.com/supabase/auth-helpers#readme",
 	"dependencies": {
 		"cookie": "^0.5.0",
-		"ramda": "^0.29.0"
+		"ramda": "^0.29.0",
+		"@supabase/auth-helpers-shared": "workspace:*"
 	},
 	"devDependencies": {
 		"@supabase/supabase-js": "2.33.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
 
   packages/ssr:
     dependencies:
+      '@supabase/auth-helpers-shared':
+        specifier: workspace:*
+        version: link:../shared
       cookie:
         specifier: ^0.5.0
         version: 0.5.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug - fixes #649
Use CookieAuthStorageAdapter to allow cookie parsing/serialization for SupabaseClient when using @supabase/ssr

This incorporates #609 by @csenio to allow async getCookie methods for the StorageAdapter and `get` method for `ServerCookieMethods` in `createServerClient` in the 

## What is the current behavior?

Issue described in #649

## What is the new behavior?

Creates a storage adapter `ServerCookieAuthStorageAdapter` in `packages/ssr/src/createServerClient.ts` by extending `CookieAuthStorageAdapter` which provides the cookie parsing/serialization expected by SupabaseClient's storage adapter.
