### PR TITLE
fix: include cookieOptions for deleteCookie

### DIFF
--- a/.changeset/empty-carrots-learn.md
+++ b/.changeset/empty-carrots-learn.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+include cookie options for deleteCookie

--- a/packages/nextjs/src/routeHandlerClient.ts
+++ b/packages/nextjs/src/routeHandlerClient.ts
@@ -31,6 +31,7 @@ class NextRouteHandlerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	protected deleteCookie(name: string): void {
 		const nextCookies = this.context.cookies();
 		nextCookies.set(name, '', {
+			...this.cookieOptions,
 			maxAge: 0
 		});
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `this.cookieOptions` when calling `deleteCookie`

## What is the current behavior?

If cookie is set by a specific domain it cannot be deleted since `deleteCookie` only specifiy `maxAge` as option and not others like `domain`.
