### PR TITLE
Chore: make cookie functions optional in server client

### DIFF
--- a/.changeset/great-beds-pull.md
+++ b/.changeset/great-beds-pull.md
@@ -1,0 +1,5 @@
+---
+'@supabase/ssr': patch
+---
+
+Fixed types for cookie methods

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -8,7 +8,7 @@ import type {
 	GenericSchema,
 	SupabaseClientOptions
 } from '@supabase/supabase-js/dist/module/lib/types';
-import type { BrowserCookieMethods, CookieOptionsWithName } from './types';
+import type { CookieMethods, CookieOptionsWithName } from './types';
 
 let cachedBrowserClient: SupabaseClient<any, string> | undefined;
 
@@ -24,7 +24,7 @@ export function createBrowserClient<
 	supabaseUrl: string,
 	supabaseKey: string,
 	options?: SupabaseClientOptions<SchemaName> & {
-		cookies: BrowserCookieMethods;
+		cookies: CookieMethods;
 		cookieOptions?: CookieOptionsWithName;
 		isSingleton?: boolean;
 	}
@@ -35,7 +35,7 @@ export function createBrowserClient<
 		);
 	}
 
-	let cookies: BrowserCookieMethods = {};
+	let cookies: CookieMethods = {};
 	let isSingleton = true;
 	let cookieOptions: CookieOptionsWithName | undefined;
 	let userDefinedClientOptions;

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -58,7 +58,7 @@ export function createBrowserClient<
 			storage: {
 				getItem: async (key: string) => {
 					if (typeof cookies.get === 'function') {
-						return (await cookies.get(key)) ?? null;
+						return cookies.get(key);
 					}
 
 					if (isBrowser()) {

--- a/packages/ssr/src/createServerClient.ts
+++ b/packages/ssr/src/createServerClient.ts
@@ -32,13 +32,6 @@ export function createServerClient<
 
 	const { cookies, cookieOptions, ...userDefinedClientOptions } = options;
 
-	if (!cookies.get || !cookies.set || !cookies.remove) {
-		// todo: point to helpful docs in error message, once they have been written! 😏
-		throw new Error(
-			'The Supabase client requires functions to get, set, and remove cookies in your specific framework!'
-		);
-	}
-
 	const cookieClientOptions = {
 		global: {
 			headers: {
@@ -51,15 +44,25 @@ export function createServerClient<
 			detectSessionInUrl: isBrowser(),
 			persistSession: true,
 			storage: {
-				getItem: async (key: string) => (await cookies.get(key)) ?? null,
-				setItem: async (key: string, value: string) =>
-					await cookies.set(key, value, {
-						...DEFAULT_COOKIE_OPTIONS,
-						...cookieOptions,
-						maxAge: DEFAULT_COOKIE_OPTIONS.maxAge
-					}),
-				removeItem: async (key: string) =>
-					await cookies.remove(key, { ...DEFAULT_COOKIE_OPTIONS, ...cookieOptions, maxAge: 0 })
+				getItem: async (key: string) => {
+					if (typeof cookies.get === 'function') {
+						return cookies.get(key);
+					}
+				},
+				setItem: async (key: string, value: string) => {
+					if (typeof cookies.set === 'function') {
+						await cookies.set(key, value, {
+							...DEFAULT_COOKIE_OPTIONS,
+							...cookieOptions,
+							maxAge: DEFAULT_COOKIE_OPTIONS.maxAge
+						});
+					}
+				},
+				removeItem: async (key: string) => {
+					if (typeof cookies.remove === 'function') {
+						await cookies.remove(key, { ...DEFAULT_COOKIE_OPTIONS, ...cookieOptions, maxAge: 0 });
+					}
+				}
 			}
 		}
 	};

--- a/packages/ssr/src/createServerClient.ts
+++ b/packages/ssr/src/createServerClient.ts
@@ -6,7 +6,7 @@ import type {
 	GenericSchema,
 	SupabaseClientOptions
 } from '@supabase/supabase-js/dist/module/lib/types';
-import type { CookieOptionsWithName, ServerCookieMethods } from './types';
+import type { CookieOptionsWithName, CookieMethods } from './types';
 
 export function createServerClient<
 	Database = any,
@@ -20,7 +20,7 @@ export function createServerClient<
 	supabaseUrl: string,
 	supabaseKey: string,
 	options: SupabaseClientOptions<SchemaName> & {
-		cookies: ServerCookieMethods;
+		cookies: CookieMethods;
 		cookieOptions?: CookieOptionsWithName;
 	}
 ) {

--- a/packages/ssr/src/types.ts
+++ b/packages/ssr/src/types.ts
@@ -2,13 +2,8 @@ import type { CookieSerializeOptions } from 'cookie';
 
 export type CookieOptions = Partial<CookieSerializeOptions>;
 export type CookieOptionsWithName = { name?: string } & CookieOptions;
-export type ServerCookieMethods = {
+export type CookieMethods = {
 	get?: (key: string) => Promise<string | null | undefined> | string | null | undefined;
-	set?: (key: string, value: string, options?: CookieOptions) => Promise<void> | void;
-	remove?: (key: string, options?: CookieOptions) => Promise<void> | void;
-};
-export type BrowserCookieMethods = {
-	get?: (key: string) => Promise<string | null | undefined> | string | null | undefined;
-	set?: (key: string, value: string, options?: CookieOptions) => Promise<void> | void;
-	remove?: (key: string, options?: CookieOptions) => Promise<void> | void;
+	set?: (key: string, value: string, options: CookieOptions) => Promise<void> | void;
+	remove?: (key: string, options: CookieOptions) => Promise<void> | void;
 };

--- a/packages/ssr/src/types.ts
+++ b/packages/ssr/src/types.ts
@@ -3,9 +3,9 @@ import type { CookieSerializeOptions } from 'cookie';
 export type CookieOptions = Partial<CookieSerializeOptions>;
 export type CookieOptionsWithName = { name?: string } & CookieOptions;
 export type ServerCookieMethods = {
-	get: (key: string) => Promise<string | null | undefined> | string | null | undefined;
-	set: (key: string, value: string, options?: CookieOptions) => Promise<void> | void;
-	remove: (key: string, options?: CookieOptions) => Promise<void> | void;
+	get?: (key: string) => Promise<string | null | undefined> | string | null | undefined;
+	set?: (key: string, value: string, options?: CookieOptions) => Promise<void> | void;
+	remove?: (key: string, options?: CookieOptions) => Promise<void> | void;
 };
 export type BrowserCookieMethods = {
 	get?: (key: string) => Promise<string | null | undefined> | string | null | undefined;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the current behavior?

Cookie functions are mandatory when creating s Server client

## What is the new behavior?

Cookie functions are optional when creating s Server client

## Additional context

Next.js Server Components cannot set or remove cookies. It doesn't make sense to declare these empty functions to be able to use a Supabase client in a Server Component
