### PR TITLE
fix: header reading trying to access undefined res on nextjs

### DIFF
--- a/.changeset/hot-stingrays-laugh.md
+++ b/.changeset/hot-stingrays-laugh.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-nextjs': patch
+---
+
+Fix header and cookie trying to read undefined response body

--- a/packages/nextjs/src/pagesServerClient.ts
+++ b/packages/nextjs/src/pagesServerClient.ts
@@ -25,11 +25,13 @@ class NextServerAuthStorageAdapter extends CookieAuthStorageAdapter {
 	}
 
 	protected getCookie(name: string): string | null | undefined {
-		const setCookie = splitCookiesString(this.context.res.getHeader('set-cookie')?.toString() ?? '')
+		const setCookie = splitCookiesString(
+			this.context.res?.getHeader('set-cookie')?.toString() ?? ''
+		)
 			.map((c) => parseCookies(c)[name])
 			.find((c) => !!c);
 
-		const value = setCookie ?? this.context.req.cookies[name];
+		const value = setCookie ?? this.context.req?.cookies[name];
 		return value;
 	}
 	protected setCookie(name: string, value: string): void {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix of trying to read the header or cookie from an empty or undefined response

## What is the current behavior?

The previous behavior introduced with the latest version of nextjs (14.0.1) caused a lot of console spam in development and erroring out with 500 codes in every single request on production.

## What is the new behavior?

This fixes the console spam and the production erroring.

## Additional context

This simple fix doesnt change much, and the behavior of the auth helpers remains the same.
