### PR TITLE
Reduce cookie chunk size

### DIFF
--- a/.changeset/violet-windows-invite.md
+++ b/.changeset/violet-windows-invite.md
@@ -1,0 +1,5 @@
+---
+'@supabase/ssr': patch
+---
+
+Reduce cookie chunk size

--- a/packages/ssr/src/utils/chunker.ts
+++ b/packages/ssr/src/utils/chunker.ts
@@ -7,7 +7,7 @@ function createChunkRegExp(chunkSize: number) {
 	return new RegExp('.{1,' + chunkSize + '}', 'g');
 }
 
-const MAX_CHUNK_SIZE = 3600;
+const MAX_CHUNK_SIZE = 3180;
 const MAX_CHUNK_REGEXP = createChunkRegExp(MAX_CHUNK_SIZE);
 
 /**

--- a/packages/ssr/src/utils/constants.ts
+++ b/packages/ssr/src/utils/constants.ts
@@ -2,6 +2,6 @@ import { CookieOptions } from '../types';
 
 export const DEFAULT_COOKIE_OPTIONS: CookieOptions = {
 	path: '/',
-	maxAge: 60 * 60 * 24 * 365 * 1000,
-	httpOnly: false
+	sameSite: 'lax',
+	maxAge: 60 * 60 * 24 * 365 * 1000
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Cookie size is still too big and this PR aims to reduce that

## What is the current behavior?

The first chunk is too big so the browser ignores it and doesn't save it.

## What is the new behavior?

All chunks should be within the browser size limit

## Additional context

Addresses #668 #661 
