### PR TITLE
Set cookie default to httpOnly: false

### DIFF
--- a/.changeset/witty-months-tap.md
+++ b/.changeset/witty-months-tap.md
@@ -1,0 +1,5 @@
+---
+'@supabase/ssr': patch
+---
+
+Set cookie default to httpOnly: false

--- a/packages/ssr/src/utils/constants.ts
+++ b/packages/ssr/src/utils/constants.ts
@@ -3,5 +3,6 @@ import { CookieOptions } from '../types';
 export const DEFAULT_COOKIE_OPTIONS: CookieOptions = {
 	path: '/',
 	sameSite: 'lax',
+	httpOnly: false,
 	maxAge: 60 * 60 * 24 * 365 * 1000
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The browser cookie is not set to httpOnly: false which breaks the ssr package behaviour

## What is the new behavior?

The browser cookie is set to httpOnly: false

## Additional context

Fixes #681
