### PR TITLE
feat: base64-encode session cookie value

### DIFF
--- a/.changeset/eight-moose-sing.md
+++ b/.changeset/eight-moose-sing.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-helpers-shared': minor
+---
+
+Encode session cookies with base64

--- a/packages/shared/src/utils/cookies.ts
+++ b/packages/shared/src/utils/cookies.ts
@@ -28,7 +28,8 @@ export function parseSupabaseCookie(str: string | null | undefined): Partial<Ses
 	}
 
 	try {
-		const session = JSON.parse(str);
+		const decoder = new TextDecoder();
+		const session = JSON.parse(decoder.decode(base64url.decode(str)));
 		if (!session) {
 			return null;
 		}
@@ -42,7 +43,6 @@ export function parseSupabaseCookie(str: string | null | undefined): Partial<Ses
 
 		const [_header, payloadStr, _signature] = session[0].split('.');
 		const payload = base64url.decode(payloadStr);
-		const decoder = new TextDecoder();
 
 		const { exp, sub, ...user } = JSON.parse(decoder.decode(payload));
 
@@ -67,11 +67,13 @@ export function parseSupabaseCookie(str: string | null | undefined): Partial<Ses
 }
 
 export function stringifySupabaseSession(session: Session): string {
-	return JSON.stringify([
-		session.access_token,
-		session.refresh_token,
-		session.provider_token,
-		session.provider_refresh_token,
-		session.user?.factors ?? null
-	]);
+	return base64url.encode(
+		JSON.stringify([
+			session.access_token,
+			session.refresh_token,
+			session.provider_token,
+			session.provider_refresh_token,
+			session.user?.factors ?? null
+		])
+	);
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The session cookie value is a plain JSON string, which gets URL-encoded by most server implementations. This causes a mismatch in the length calculation in the chunker; sometimes, cookie values exceed the max length.

## What is the new behavior?

This PR base64-encodes the cookie value before passing to the chunker.

The rationale for using base64:
- it is used in the JWT encoding
- `jose` has been included and used for while
- URL encoding encodes `{`, `}`, `"`, `]` to 3 characters tripling in length, whereas base64 encoding increases `x4/3` in bytes, so overall length would be similar

## Additional context

Closes #680. Fixes #643 and fixes #696.
