### PR TITLE
feat: add `isServer` property to server-side storage adapters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3051 @@
+{
+	"name": "@supabase/auth-helpers",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@supabase/auth-helpers",
+			"version": "0.0.0",
+			"devDependencies": {
+				"@changesets/cli": "^2.27.1",
+				"husky": "^8.0.3",
+				"prettier": "^2.8.8",
+				"turbo": "^1.11.2",
+				"typedoc": "^0.24.8",
+				"typescript": "^4.9.5"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=7.0.0"
+			},
+			"peerDependencies": {
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.18.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/highlight": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.19.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.18.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.18.6",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+			"integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@changesets/apply-release-plan": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.0.tgz",
+			"integrity": "sha512-vfi69JR416qC9hWmFGSxj7N6wA5J222XNBmezSVATPWDVPIF7gkd4d8CpbEbXmRWbVrkoli3oerGS6dcL/BGsQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/config": "^3.0.0",
+				"@changesets/get-version-range-type": "^0.4.0",
+				"@changesets/git": "^3.0.0",
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"detect-indent": "^6.0.0",
+				"fs-extra": "^7.0.1",
+				"lodash.startcase": "^4.4.0",
+				"outdent": "^0.5.0",
+				"prettier": "^2.7.1",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.5.3"
+			}
+		},
+		"node_modules/@changesets/apply-release-plan/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/apply-release-plan/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/apply-release-plan/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/@changesets/assemble-release-plan": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.0.tgz",
+			"integrity": "sha512-4QG7NuisAjisbW4hkLCmGW2lRYdPrKzro+fCtZaILX+3zdUELSvYjpL4GTv0E4aM9Mef3PuIQp89VmHJ4y2bfw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/get-dependents-graph": "^2.0.0",
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"semver": "^7.5.3"
+			}
+		},
+		"node_modules/@changesets/assemble-release-plan/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/assemble-release-plan/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/assemble-release-plan/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/@changesets/changelog-git": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.0.tgz",
+			"integrity": "sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==",
+			"dev": true,
+			"dependencies": {
+				"@changesets/types": "^6.0.0"
+			}
+		},
+		"node_modules/@changesets/cli": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.1.tgz",
+			"integrity": "sha512-iJ91xlvRnnrJnELTp4eJJEOPjgpF3NOh4qeQehM6Ugiz9gJPRZ2t+TsXun6E3AMN4hScZKjqVXl0TX+C7AB3ZQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/apply-release-plan": "^7.0.0",
+				"@changesets/assemble-release-plan": "^6.0.0",
+				"@changesets/changelog-git": "^0.2.0",
+				"@changesets/config": "^3.0.0",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/get-dependents-graph": "^2.0.0",
+				"@changesets/get-release-plan": "^4.0.0",
+				"@changesets/git": "^3.0.0",
+				"@changesets/logger": "^0.1.0",
+				"@changesets/pre": "^2.0.0",
+				"@changesets/read": "^0.6.0",
+				"@changesets/types": "^6.0.0",
+				"@changesets/write": "^0.3.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"@types/semver": "^7.5.0",
+				"ansi-colors": "^4.1.3",
+				"chalk": "^2.1.0",
+				"ci-info": "^3.7.0",
+				"enquirer": "^2.3.0",
+				"external-editor": "^3.1.0",
+				"fs-extra": "^7.0.1",
+				"human-id": "^1.0.2",
+				"meow": "^6.0.0",
+				"outdent": "^0.5.0",
+				"p-limit": "^2.2.0",
+				"preferred-pm": "^3.0.0",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.5.3",
+				"spawndamnit": "^2.0.0",
+				"term-size": "^2.1.0",
+				"tty-table": "^4.1.5"
+			},
+			"bin": {
+				"changeset": "bin.js"
+			}
+		},
+		"node_modules/@changesets/cli/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/cli/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/cli/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/@changesets/config": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.0.tgz",
+			"integrity": "sha512-o/rwLNnAo/+j9Yvw9mkBQOZySDYyOr/q+wptRLcAVGlU6djOeP9v1nlalbL9MFsobuBVQbZCTp+dIzdq+CLQUA==",
+			"dev": true,
+			"dependencies": {
+				"@changesets/errors": "^0.2.0",
+				"@changesets/get-dependents-graph": "^2.0.0",
+				"@changesets/logger": "^0.1.0",
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"fs-extra": "^7.0.1",
+				"micromatch": "^4.0.2"
+			}
+		},
+		"node_modules/@changesets/errors": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+			"integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+			"dev": true,
+			"dependencies": {
+				"extendable-error": "^0.1.5"
+			}
+		},
+		"node_modules/@changesets/get-dependents-graph": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.0.0.tgz",
+			"integrity": "sha512-cafUXponivK4vBgZ3yLu944mTvam06XEn2IZGjjKc0antpenkYANXiiE6GExV/yKdsCnE8dXVZ25yGqLYZmScA==",
+			"dev": true,
+			"dependencies": {
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"chalk": "^2.1.0",
+				"fs-extra": "^7.0.1",
+				"semver": "^7.5.3"
+			}
+		},
+		"node_modules/@changesets/get-dependents-graph/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/get-dependents-graph/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@changesets/get-dependents-graph/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/@changesets/get-release-plan": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.0.tgz",
+			"integrity": "sha512-9L9xCUeD/Tb6L/oKmpm8nyzsOzhdNBBbt/ZNcjynbHC07WW4E1eX8NMGC5g5SbM5z/V+MOrYsJ4lRW41GCbg3w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/assemble-release-plan": "^6.0.0",
+				"@changesets/config": "^3.0.0",
+				"@changesets/pre": "^2.0.0",
+				"@changesets/read": "^0.6.0",
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3"
+			}
+		},
+		"node_modules/@changesets/get-version-range-type": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+			"integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+			"dev": true
+		},
+		"node_modules/@changesets/git": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.0.tgz",
+			"integrity": "sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"is-subdir": "^1.1.1",
+				"micromatch": "^4.0.2",
+				"spawndamnit": "^2.0.0"
+			}
+		},
+		"node_modules/@changesets/logger": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.0.tgz",
+			"integrity": "sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.1.0"
+			}
+		},
+		"node_modules/@changesets/parse": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.0.tgz",
+			"integrity": "sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==",
+			"dev": true,
+			"dependencies": {
+				"@changesets/types": "^6.0.0",
+				"js-yaml": "^3.13.1"
+			}
+		},
+		"node_modules/@changesets/pre": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.0.tgz",
+			"integrity": "sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/types": "^6.0.0",
+				"@manypkg/get-packages": "^1.1.3",
+				"fs-extra": "^7.0.1"
+			}
+		},
+		"node_modules/@changesets/read": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.0.tgz",
+			"integrity": "sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/git": "^3.0.0",
+				"@changesets/logger": "^0.1.0",
+				"@changesets/parse": "^0.4.0",
+				"@changesets/types": "^6.0.0",
+				"chalk": "^2.1.0",
+				"fs-extra": "^7.0.1",
+				"p-filter": "^2.1.0"
+			}
+		},
+		"node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
+		"node_modules/@changesets/write": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.0.tgz",
+			"integrity": "sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"@changesets/types": "^6.0.0",
+				"fs-extra": "^7.0.1",
+				"human-id": "^1.0.2",
+				"prettier": "^2.7.1"
+			}
+		},
+		"node_modules/@manypkg/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"@types/node": "^12.7.1",
+				"find-up": "^4.1.0",
+				"fs-extra": "^8.1.0"
+			}
+		},
+		"node_modules/@manypkg/find-root/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/@manypkg/get-packages": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+			"integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"@changesets/types": "^4.0.1",
+				"@manypkg/find-root": "^1.1.0",
+				"fs-extra": "^8.1.0",
+				"globby": "^11.0.0",
+				"read-yaml-file": "^1.1.0"
+			}
+		},
+		"node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+			"integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+			"dev": true
+		},
+		"node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@types/minimist": {
+			"version": "1.2.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"dev": true
+		},
+		"node_modules/@types/normalize-package-data": {
+			"version": "2.4.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/semver": {
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+			"dev": true
+		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-sequence-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+			"dev": true
+		},
+		"node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.3.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/arrify": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/better-path-resolve": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+			"integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+			"dev": true,
+			"dependencies": {
+				"is-windows": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/breakword": {
+			"version": "1.0.5",
+			"dev": true,
+			"license": "gpl-2.0",
+			"dependencies": {
+				"wcwidth": "^1.0.1"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camelcase-keys": {
+			"version": "6.2.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"map-obj": "^4.0.0",
+				"quick-lru": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "2.4.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chardet": {
+			"version": "0.7.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/clone": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"node_modules/csv": {
+			"version": "5.5.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"csv-generate": "^3.4.3",
+				"csv-parse": "^4.16.3",
+				"csv-stringify": "^5.6.5",
+				"stream-transform": "^2.1.3"
+			},
+			"engines": {
+				"node": ">= 0.1.90"
+			}
+		},
+		"node_modules/csv-generate": {
+			"version": "3.4.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/csv-parse": {
+			"version": "4.16.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/csv-stringify": {
+			"version": "5.6.5",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/decamelize-keys": {
+			"version": "1.1.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decamelize-keys/node_modules/map-obj": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/defaults": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-indent": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/enquirer": {
+			"version": "2.3.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-colors": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-abstract": {
+			"version": "1.20.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
+				"get-intrinsic": "^1.1.3",
+				"get-symbol-description": "^1.0.0",
+				"has": "^1.0.3",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.3",
+				"is-callable": "^1.2.7",
+				"is-negative-zero": "^2.0.2",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"is-string": "^1.0.7",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.2",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has": "^1.0.3"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.2.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/extendable-error": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+			"integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+			"dev": true
+		},
+		"node_modules/external-editor": {
+			"version": "3.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fastq": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+			"integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-yarn-workspace-root2": {
+			"version": "1.2.16",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2",
+				"pkg-dir": "^4.2.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.5",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.1.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.10",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/grapheme-splitter": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hard-rejection": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/has-bigints": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "2.8.9",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/human-id": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
+			"integrity": "sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==",
+			"dev": true
+		},
+		"node_modules/husky": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+			"integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+			"dev": true,
+			"bin": {
+				"husky": "lib/bin.js"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/internal-slot": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.1.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-bigint": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.11.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.0.5",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.0.7",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "1.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-string": {
+			"version": "1.0.7",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-subdir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+			"integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+			"dev": true,
+			"dependencies": {
+				"better-path-resolve": "1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
+		"node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/kleur": {
+			"version": "4.1.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/load-yaml-file": {
+			"version": "0.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.5",
+				"js-yaml": "^3.13.0",
+				"pify": "^4.0.1",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lodash.startcase": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+			"integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+			"dev": true
+		},
+		"node_modules/lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/map-obj": {
+			"version": "4.3.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"dev": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/meow": {
+			"version": "6.1.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/minimist": "^1.2.0",
+				"camelcase-keys": "^6.2.2",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "^4.0.2",
+				"normalize-package-data": "^2.5.0",
+				"read-pkg-up": "^7.0.1",
+				"redent": "^3.0.0",
+				"trim-newlines": "^3.0.0",
+				"type-fest": "^0.13.1",
+				"yargs-parser": "^18.1.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.5",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/min-indent": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minimist-options": {
+			"version": "4.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0",
+				"kind-of": "^6.0.3"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/mixme": {
+			"version": "0.5.4",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/normalize-package-data": {
+			"version": "2.5.0",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.12.2",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/outdent": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+			"integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+			"dev": true
+		},
+		"node_modules/p-filter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+			"integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+			"dev": true,
+			"dependencies": {
+				"p-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "2.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "4.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/preferred-pm": {
+			"version": "3.0.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^5.0.0",
+				"find-yarn-workspace-root2": "1.2.16",
+				"path-exists": "^4.0.0",
+				"which-pm": "2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/preferred-pm/node_modules/find-up": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/preferred-pm/node_modules/locate-path": {
+			"version": "6.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/preferred-pm/node_modules/p-limit": {
+			"version": "3.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/preferred-pm/node_modules/p-locate": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+			"dev": true
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/quick-lru": {
+			"version": "4.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/read-pkg": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/read-pkg-up": {
+			"version": "7.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg-up/node_modules/type-fest": {
+			"version": "0.8.1",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "0.6.0",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/read-yaml-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+			"integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.1.5",
+				"js-yaml": "^3.6.1",
+				"pify": "^4.0.1",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/redent": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.4.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/resolve": {
+			"version": "1.22.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "5.7.1",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shiki": {
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-sequence-parser": "^1.1.0",
+				"jsonc-parser": "^3.2.0",
+				"vscode-oniguruma": "^1.7.0",
+				"vscode-textmate": "^8.0.0"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.0.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/smartwrap": {
+			"version": "2.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flat": "^1.2.3",
+				"breakword": "^1.0.5",
+				"grapheme-splitter": "^1.0.4",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1",
+				"yargs": "^15.1.0"
+			},
+			"bin": {
+				"smartwrap": "src/terminal-adapter.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/smartwrap/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/smartwrap/node_modules/cliui": {
+			"version": "6.0.0",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/smartwrap/node_modules/color-convert": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/smartwrap/node_modules/color-name": {
+			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/smartwrap/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/smartwrap/node_modules/y18n": {
+			"version": "4.0.3",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/smartwrap/node_modules/yargs": {
+			"version": "15.4.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/spawndamnit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
+			"integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/spdx-correct": {
+			"version": "3.1.1",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-exceptions": {
+			"version": "2.3.0",
+			"dev": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.12",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/stream-transform": {
+			"version": "2.1.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mixme": "^0.5.1"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.5",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.5",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/strip-indent": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "5.5.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/term-size": {
+			"version": "2.2.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/trim-newlines": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/tty-table": {
+			"version": "4.1.6",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"csv": "^5.5.0",
+				"kleur": "^4.1.4",
+				"smartwrap": "^2.0.2",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1",
+				"yargs": "^17.1.1"
+			},
+			"bin": {
+				"tty-table": "adapters/terminal-adapter.js"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/tty-table/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/tty-table/node_modules/chalk": {
+			"version": "4.1.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/tty-table/node_modules/color-convert": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/tty-table/node_modules/color-name": {
+			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tty-table/node_modules/has-flag": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/tty-table/node_modules/supports-color": {
+			"version": "7.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/turbo": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-1.11.3.tgz",
+			"integrity": "sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==",
+			"dev": true,
+			"bin": {
+				"turbo": "bin/turbo"
+			},
+			"optionalDependencies": {
+				"turbo-darwin-64": "1.11.3",
+				"turbo-darwin-arm64": "1.11.3",
+				"turbo-linux-64": "1.11.3",
+				"turbo-linux-arm64": "1.11.3",
+				"turbo-windows-64": "1.11.3",
+				"turbo-windows-arm64": "1.11.3"
+			}
+		},
+		"node_modules/turbo-darwin-64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.11.3.tgz",
+			"integrity": "sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/turbo-darwin-arm64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.3.tgz",
+			"integrity": "sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/turbo-linux-64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.11.3.tgz",
+			"integrity": "sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/turbo-linux-arm64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.11.3.tgz",
+			"integrity": "sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/turbo-windows-64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.11.3.tgz",
+			"integrity": "sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/turbo-windows-arm64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.11.3.tgz",
+			"integrity": "sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/type-fest": {
+			"version": "0.13.1",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typedoc": {
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+			"integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+			"dev": true,
+			"dependencies": {
+				"lunr": "^2.3.9",
+				"marked": "^4.3.0",
+				"minimatch": "^9.0.0",
+				"shiki": "^0.14.1"
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 14.14"
+			},
+			"peerDependencies": {
+				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+			"dev": true
+		},
+		"node_modules/vscode-textmate": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+			"dev": true
+		},
+		"node_modules/wcwidth": {
+			"version": "1.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-module": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/which-pm": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"load-yaml-file": "^0.2.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8.15"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+			"dev": true
+		},
+		"node_modules/yargs": {
+			"version": "17.6.2",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
+}

--- a/packages/nextjs/src/serverComponentClient.ts
+++ b/packages/nextjs/src/serverComponentClient.ts
@@ -11,6 +11,8 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
 
 class NextServerComponentAuthStorageAdapter extends CookieAuthStorageAdapter {
+	readonly isServer = true;
+
 	constructor(
 		private readonly context: {
 			cookies: () => ReturnType<typeof cookies>;

--- a/packages/remix/src/createSupabaseClient.ts
+++ b/packages/remix/src/createSupabaseClient.ts
@@ -132,6 +132,8 @@ export function createBrowserClient<
 }
 
 class RemixServerAuthStorageAdapter extends CookieAuthStorageAdapter {
+	readonly isServer = true;
+
 	constructor(
 		private readonly request: Request,
 		private readonly response: Response,

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -62,6 +62,8 @@ export function createBrowserClient<
 			detectSessionInUrl: isBrowser(),
 			persistSession: true,
 			storage: {
+				// this client is used on the browser so cookies can be trusted
+				isServer: false,
 				getItem: async (key: string) => {
 					const chunkedCookie = await combineChunks(key, async (chunkName) => {
 						if (typeof cookies.get === 'function') {

--- a/packages/ssr/src/createServerClient.ts
+++ b/packages/ssr/src/createServerClient.ts
@@ -50,6 +50,8 @@ export function createServerClient<
 			detectSessionInUrl: isBrowser(),
 			persistSession: true,
 			storage: {
+				// to signal to the libraries that these cookies are coming from a server environment and their value should not be trusted
+				isServer: true,
 				getItem: async (key: string) => {
 					const chunkedCookie = await combineChunks(key, async (chunkName: string) => {
 						if (typeof cookies.get === 'function') {

--- a/packages/sveltekit/src/serverStorageAdapter.ts
+++ b/packages/sveltekit/src/serverStorageAdapter.ts
@@ -3,6 +3,8 @@ import { Session } from '@supabase/supabase-js';
 import { RequestEvent } from '@sveltejs/kit';
 
 export class SvelteKitServerAuthStorageAdapter extends CookieAuthStorageAdapter {
+	readonly isServer = true;
+
 	private isInitialDelete = true;
 	private currentSession: Partial<Session> | null = null;
 


### PR DESCRIPTION
This property will be picked up by [auth-js (formerly known as gotrue-js)](https://github.com/supabase/gotrue-js) to warn or adjust behavior given that the storage medium (in this case cookies) cannot be trusted.