### PR TITLE
fix(chunker): Fix chunk length calculation for unicode characters

### DIFF
--- a/packages/ssr/src/utils/chunker.ts
+++ b/packages/ssr/src/utils/chunker.ts
@@ -32,7 +32,7 @@ export function createChunks(key: string, value: string, chunkSize?: number): Ch
 			encodedChunkHead = encodedChunkHead.slice(0, lastEscapePos);
 		}
 
-		let valueHead: string;
+		let valueHead: string = '';
 
 		// Check if the chunk was split along a valid unicode boundary.
 		while (encodedChunkHead.length > 0) {

--- a/packages/ssr/src/utils/chunker.ts
+++ b/packages/ssr/src/utils/chunker.ts
@@ -17,7 +17,7 @@ export function createChunks(key: string, value: string, chunkSize?: number): Ch
 		return [{ name: key, value }];
 	}
 
-	const chunks = [];
+	const chunks: string[] = [];
 
 	while (encodedValue.length > 0) {
 		let encodedChunkHead = encodedValue.slice(0, resolvedChunkSize);
@@ -32,7 +32,7 @@ export function createChunks(key: string, value: string, chunkSize?: number): Ch
 			encodedChunkHead = encodedChunkHead.slice(0, lastEscapePos);
 		}
 
-		let valueHead;
+		let valueHead: string;
 
 		// Check if the chunk was split along a valid unicode boundary.
 		while (encodedChunkHead.length > 0) {

--- a/packages/ssr/tests/chunker.spec.ts
+++ b/packages/ssr/tests/chunker.spec.ts
@@ -64,4 +64,83 @@ describe('chunker', () => {
 		expect(len(`${key}=${DOUBLE_CHUNK_STRING}`)).toBe(7257);
 		expect(combined).toBe(DOUBLE_CHUNK_STRING);
 	});
+
+	it('should correctly break between unicode boundaries in escaped characters', () => {
+		const test = '   ';
+		const chunks = createChunks('key', test, 4);
+		expect(chunks).toEqual([
+			{
+				name: 'key.0',
+				value: ' '
+			},
+			{
+				name: 'key.1',
+				value: ' '
+			},
+			{
+				name: 'key.2',
+				value: ' '
+			}
+		]);
+
+		expect(chunks.map((char) => char.value).join('')).toEqual(test);
+	});
+
+	describe('should correctly break between unicode boundaries in long unicode', () => {
+		it('should correctly break between unicode boundaries in long unicode (4 bytes)', () => {
+			const test = '🤦🏻‍♂️';
+			const chunksAtStartBorder = createChunks('key', test, 12);
+			const chunksAtEndBorder = createChunks('key', test, 17);
+			expect(chunksAtStartBorder).toEqual(chunksAtEndBorder);
+			expect(chunksAtStartBorder).toEqual([
+				{
+					name: 'key.0',
+					value: '🤦'
+				},
+				{
+					name: 'key.1',
+					value: '🏻'
+				},
+				{
+					name: 'key.2',
+					value: '‍'
+				},
+				{
+					name: 'key.3',
+					value: '♂'
+				},
+				{
+					name: 'key.4',
+					value: '️'
+				}
+			]);
+			expect(chunksAtStartBorder.map((char) => char.value).join('')).toEqual(test);
+		});
+
+		it('should correctly break between unicode boundaries in long unicode (5 bytes)', () => {
+			const test = '🤦🏻‍♂️';
+			const chunksAtStartBorder = createChunks('key', test, 18);
+			const chunksAtEndBorder = createChunks('key', test, 20);
+			expect(chunksAtStartBorder).toEqual(chunksAtEndBorder);
+			expect(chunksAtStartBorder).toEqual([
+				{
+					name: 'key.0',
+					value: '🤦'
+				},
+				{
+					name: 'key.1',
+					value: '🏻'
+				},
+				{
+					name: 'key.2',
+					value: '‍♂'
+				},
+				{
+					name: 'key.3',
+					value: '️'
+				}
+			]);
+			expect(chunksAtStartBorder.map((char) => char.value).join('')).toEqual(test);
+		});
+	});
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The length of cookies with URI escaped characters can exceed the valid cookie length of 4096, causing parts of the split cookies to be rejected by the browser.

## What is the new behavior?

Chunked cookies after URI encoding now fit within the chunk size specified.

## Additional context

The reason for this issue occurring is that we are chunking base on lengths before escaping. While we have some buffer in the `MAX_CHUNK_SIZE` for longer unicode characters, this does not always work.

For example `﷽` has a length in javascript of `1` as well as match `/(.{1})/g.exec("﷽") ` to be `$1 = ﷽`, but it will escape to `%EF%B7%BD` which is 9 characters long.

The current approach of chunking with a buffer for some unicode characters will never be "correct" unless we implement a buffer that accounts for every character being a maximum size unicode.

I've reimplemented the createChunks function to do the following:
1. Split the chunk after encoding it.
2. Ensure that chunks are split correctly between unicode characters instead of inside of it.
3. Not use regex as it is hard to determine what a "correct" unicode character boundary is in regex when it is escaped.

There are currently other related solutions and issues:

__PRs__
- #680
- #701

__Issues__
- #707 
- #715 
