### PR TITLE
fix: use cookie name as storage key

### DIFF
--- a/packages/ssr/src/createServerClient.ts
+++ b/packages/ssr/src/createServerClient.ts
@@ -38,6 +38,14 @@ export function createServerClient<
 
 	const { cookies, cookieOptions, ...userDefinedClientOptions } = options;
 
+	// use the cookie name as the storageKey value if it's set
+	if (cookieOptions?.name) {
+		userDefinedClientOptions.auth = {
+			...userDefinedClientOptions.auth,
+			storageKey: cookieOptions.name
+		};
+	}
+
 	const cookieClientOptions = {
 		global: {
 			headers: {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Currently, setting a custom cookie name via the `cookieOptions` breaks the client because the cookies will be set with the custom name but `getItem` uses the `storageKey` value to retrieve the cookie