### PR TITLE
chore: add auth team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @supabase/auth


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds the auth team as the codeowners for the auth helpers