### PR TITLE
fix: make the cookie option optional when providing options to createBrowserClient

### DIFF
--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -30,7 +30,7 @@ export function createBrowserClient<
 	supabaseUrl: string,
 	supabaseKey: string,
 	options?: SupabaseClientOptions<SchemaName> & {
-		cookies: CookieMethods;
+		cookies?: CookieMethods;
 		cookieOptions?: CookieOptionsWithName;
 		isSingleton?: boolean;
 	}
@@ -47,7 +47,7 @@ export function createBrowserClient<
 	let userDefinedClientOptions;
 
 	if (options) {
-		({ cookies, isSingleton = true, cookieOptions, ...userDefinedClientOptions } = options);
+		({ cookies = {}, isSingleton = true, cookieOptions, ...userDefinedClientOptions } = options);
 	}
 
 	const cookieClientOptions = {

--- a/packages/ssr/tests/createBrowserClient.spec.ts
+++ b/packages/ssr/tests/createBrowserClient.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBrowserClient } from '../src/createBrowserClient';
+
+describe('createBrowserClient', () => {
+	it('should throw an error when required parameters are not provided', () => {
+		// @ts-expect-error
+		expect(() => createBrowserClient()).toThrowError(/URL and Key/);
+	});
+
+	it('should throw an error when the provided URL is not a well-formed http address', () => {
+		expect(() => createBrowserClient('test', 'test')).toThrow(/Invalid URL/);
+	});
+
+	it('should use cookie methods provided as options when creating a client', async () => {
+		const cookies = {
+			get(_key: string) {
+				return '';
+			}
+		};
+
+		const getCookieSpy = vi.spyOn(cookies, 'get');
+
+		const client = createBrowserClient('https://test.com', 'test', {
+			cookies
+		});
+
+		// The client accesses cookies while retrieving the session
+		await client.auth.getSession();
+
+		expect(getCookieSpy).toHaveBeenCalledWith('sb-test-auth-token');
+	});
+});

--- a/packages/ssr/vite.config.ts
+++ b/packages/ssr/vite.config.ts
@@ -1,0 +1,12 @@
+import type { UserConfig } from 'vite';
+import pkg from './package.json';
+
+// https://vitejs.dev/config/
+const config: UserConfig = {
+	define: {
+		PACKAGE_NAME: JSON.stringify(pkg.name.replace('@', '').replace('/', '-')),
+		PACKAGE_VERSION: JSON.stringify(pkg.version)
+	}
+};
+
+export default config;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a proposed fix for the typings for the `options` argument provided when constructing a client via `createBrowserClient()`. The `options` argument is optional, but when providing options such as `auth`, you must also provide the `cookies` option since it is marked as required according to the current function signature.

## What is the current behavior?

When customising any options when creating a browser client, the `cookies` options must also be provided, even if no extended functionality is required/wanted.

## What is the new behavior?

The `cookies` option is no longer required when providing any other options.

## Additional context

This is a proposed improvement for a workaround suggested [here](https://github.com/supabase/auth-helpers/issues/682#issuecomment-1807003220), and partially responds to feedback provided [here](https://github.com/supabase/auth-helpers/issues/721), that it should not always be required, and that providing customisations to cookies has no effect (tests were added to verify, but I could not reproduce the issue).