### PR TITLE
fix: add `undefined` to `serverSession` type

### DIFF
--- a/packages/sveltekit/src/supabaseLoadClient.ts
+++ b/packages/sveltekit/src/supabaseLoadClient.ts
@@ -74,7 +74,7 @@ export function createSupabaseLoadClient<
 	/**
 	 * The initial session from the server.
 	 */
-	serverSession: Session | null;
+	serverSession: Session | null | undefined;
 	options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
 	cookieOptions?: CookieOptionsWithName;
 }): SupabaseClient<Database, SchemaName, Schema> {


### PR DESCRIPTION
Extends the `serverSession` type with undefined similar to other types in the codebase that allow for null.

Mainly to satisfy TS linters. Went with `fix:` but might be a `chore:`?

| current | updated |
| :---: | :---: |
| <img width="942" alt="aft" src="https://github.com/supabase/auth-helpers/assets/34311583/1403a107-3974-4bb6-9cd1-e64ee9fcd635"> | <img width="942" alt="bef" src="https://github.com/supabase/auth-helpers/assets/34311583/84224db4-92c2-4a8a-a932-19f561f78b2f"> |


