### PR TITLE
fix: allow setting custom cookie name in createBrowserClient

### DIFF
--- a/.changeset/proud-coins-help.md
+++ b/.changeset/proud-coins-help.md
@@ -1,0 +1,5 @@
+---
+'@supabase/ssr': minor
+---
+
+fix custom cookie options in browser client

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -50,6 +50,13 @@ export function createBrowserClient<
 		({ cookies, isSingleton = true, cookieOptions, ...userDefinedClientOptions } = options);
 	}
 
+	if (cookieOptions?.name) {
+		userDefinedClientOptions.auth = {
+			...userDefinedClientOptions.auth,
+			storageKey: cookieOptions.name
+		};
+	}
+
 	const cookieClientOptions = {
 		global: {
 			headers: {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Address [the comment](https://github.com/supabase/auth-helpers/issues/717#issuecomment-1962251408) raised in #717 
* `createBrowserClient` in the ssr package also doesn't seem to respect the custom cookie name used