### PR TITLE
fix: bump supabase-js to match lastest types.

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -28,7 +28,7 @@
 	},
 	"homepage": "https://github.com/supabase/auth-helpers/tree/main/packages/nextjs#readme",
 	"devDependencies": {
-		"@supabase/supabase-js": "2.19.0",
+		"@supabase/supabase-js": "2.39.8",
 		"@types/set-cookie-parser": "^2.4.3",
 		"config": "workspace:*",
 		"next": "^13.5.1",
@@ -44,6 +44,6 @@
 		"set-cookie-parser": "^2.6.0"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.19.0"
+		"@supabase/supabase-js": "^2.39.8"
 	}
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
 	"author": "Supabase",
 	"license": "MIT",
 	"devDependencies": {
-		"@supabase/supabase-js": "2.19.0",
+		"@supabase/supabase-js": "2.39.8",
 		"@types/react": "^17.0.65",
 		"@types/react-dom": "^17.0.20",
 		"config": "workspace:*",
@@ -35,6 +35,6 @@
 		"typescript": "^4.9.5"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.19.0"
+		"@supabase/supabase-js": "^2.39.8"
 	}
 }

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -31,7 +31,7 @@
 		"@remix-run/node": "^1.19.3",
 		"@remix-run/react": "^1.19.3",
 		"@remix-run/serve": "^1.19.3",
-		"@supabase/supabase-js": "2.19.0",
+		"@supabase/supabase-js": "2.39.8",
 		"config": "workspace:*",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
@@ -44,6 +44,6 @@
 		"@supabase/auth-helpers-shared": "workspace:*"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.19.0"
+		"@supabase/supabase-js": "^2.39.8"
 	}
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,7 +33,7 @@
 	},
 	"homepage": "https://github.com/supabase/auth-helpers#readme",
 	"devDependencies": {
-		"@supabase/supabase-js": "2.19.0",
+		"@supabase/supabase-js": "2.39.8",
 		"@types/cookie": "^0.5.1",
 		"cookie": "^0.5.0",
 		"next": "^13.5.5",
@@ -47,6 +47,6 @@
 		"jose": "^4.14.4"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.19.0"
+		"@supabase/supabase-js": "^2.39.8"
 	}
 }

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -40,7 +40,7 @@
 	},
 	"homepage": "https://github.com/supabase/auth-helpers/tree/main/packages/sveltekit#readme",
 	"devDependencies": {
-		"@supabase/supabase-js": "2.19.0",
+		"@supabase/supabase-js": "2.39.8",
 		"@sveltejs/kit": "^2.4.3",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"rimraf": "^4.4.1",
@@ -55,7 +55,7 @@
 		"@supabase/auth-helpers-shared": "workspace:*"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.19.0",
+		"@supabase/supabase-js": "^2.39.8",
 		"@sveltejs/kit": "^1.30.3 || ^2.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         version: 2.6.0
     devDependencies:
       '@supabase/supabase-js':
-        specifier: 2.19.0
-        version: 2.19.0
+        specifier: 2.39.8
+        version: 2.39.8
       '@types/set-cookie-parser':
         specifier: ^2.4.3
         version: 2.4.7
@@ -297,8 +297,8 @@ importers:
   packages/react:
     devDependencies:
       '@supabase/supabase-js':
-        specifier: 2.19.0
-        version: 2.19.0
+        specifier: 2.39.8
+        version: 2.39.8
       '@types/react':
         specifier: ^17.0.65
         version: 17.0.75
@@ -343,8 +343,8 @@ importers:
         specifier: ^1.19.3
         version: 1.19.3
       '@supabase/supabase-js':
-        specifier: 2.19.0
-        version: 2.19.0
+        specifier: 2.39.8
+        version: 2.39.8
       config:
         specifier: workspace:*
         version: link:../config
@@ -374,8 +374,8 @@ importers:
         version: 4.15.4
     devDependencies:
       '@supabase/supabase-js':
-        specifier: 2.19.0
-        version: 2.19.0
+        specifier: 2.39.8
+        version: 2.39.8
       '@types/cookie':
         specifier: ^0.5.1
         version: 0.5.4
@@ -436,8 +436,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@supabase/supabase-js':
-        specifier: 2.19.0
-        version: 2.19.0
+        specifier: 2.39.8
+        version: 2.39.8
       '@sveltejs/kit':
         specifier: ^2.4.3
         version: 2.5.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.9)(vite@5.0.12)
@@ -3320,21 +3320,6 @@ packages:
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
-  /@supabase/supabase-js@2.19.0:
-    resolution: {integrity: sha512-LO+uMy4lnmLvpdF5vGSEQgurxoj8qx4LiZve555JeAnrnuyubvDLZ8Kk5nU0+9KRi4VGQIeD5znqMh0OaACj4w==}
-    dependencies:
-      '@supabase/functions-js': 2.1.5
-      '@supabase/gotrue-js': 2.62.2
-      '@supabase/postgrest-js': 1.9.2
-      '@supabase/realtime-js': 2.9.3
-      '@supabase/storage-js': 2.5.5
-      cross-fetch: 3.1.8
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
-    dev: true
-
   /@supabase/supabase-js@2.33.1:
     resolution: {integrity: sha512-jA00rquPTppPOHpBB6KABW98lfg0gYXcuGqP3TB1iiduznRVsi3GGk2qBKXPDLMYSe0kRlQp5xCwWWthaJr8eA==}
     dependencies:
@@ -3363,6 +3348,20 @@ packages:
       - bufferutil
       - utf-8-validate
     dev: false
+
+  /@supabase/supabase-js@2.39.8:
+    resolution: {integrity: sha512-WpiawHjseIRcCQTZbMJtHUSOepz5+M9qE1jP9BDmg8X7ehALFwgEkiKyHAu59qm/pKP2ryyQXLtu2XZNRbUarw==}
+    dependencies:
+      '@supabase/functions-js': 2.1.5
+      '@supabase/gotrue-js': 2.62.2
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.9.2
+      '@supabase/realtime-js': 2.9.3
+      '@supabase/storage-js': 2.5.5
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
 
   /@sveltejs/adapter-auto@2.1.1(@sveltejs/kit@1.30.3):
     resolution: {integrity: sha512-nzi6x/7/3Axh5VKQ8Eed3pYxastxoa06Y/bFhWb7h3Nu+nGRVxKAy3+hBJgmPCwWScy8n0TsstZjSVKfyrIHkg==}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix. right now types definitions are not working when using ssr library added https://github.com/supabase/storage-js/pull/190
<img width="772" alt="image" src="https://github.com/supabase/auth-helpers/assets/83733486/5e156ecb-fb14-4469-a2eb-1babd989c472">
When in the console when we log the data is -> 
<img width="483" alt="image" src="https://github.com/supabase/auth-helpers/assets/83733486/96adc72e-f337-492b-9c4d-3d3c2a486f38">


## What is the current behavior?

I'm not having type completation

