### PR TITLE
Fixing createBrowserClient.ts to not fail accessing cookie properties…

### DIFF
--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -48,6 +48,7 @@ export function createBrowserClient<
 
 	if (options) {
 		({ cookies, isSingleton = true, cookieOptions, ...userDefinedClientOptions } = options);
+		cookies = cookies || {}; 
 	}
 
 	const cookieClientOptions = {


### PR DESCRIPTION
… like get/set/remove

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If you provide `{auth: {storage: {storageKey}}}` as option it will make the cookies variable undefined and fail.

## What is the new behavior?

Doesn't fail anymore and works properly.