### PR TITLE
Update createBrowserClient.ts to allow for ONE option only instead of…

### DIFF
--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -30,7 +30,7 @@ export function createBrowserClient<
 	supabaseUrl: string,
 	supabaseKey: string,
 	options?: SupabaseClientOptions<SchemaName> & {
-		cookies: CookieMethods;
+		cookies?: CookieMethods;
 		cookieOptions?: CookieOptionsWithName;
 		isSingleton?: boolean;
 	}


### PR DESCRIPTION
… enforcing cookies

## What kind of change does this PR introduce?

It fixes essentially just a TS issue that I was forced to do 

`cookies: {} as any` 

to fallback to the original cookie implementation whilst providing e.g. `cookieOptions`
