### PR TITLE
fix: small improvements/fixes to cookie chunker in ssr

### DIFF
--- a/.changeset/bright-ravens-confess.md
+++ b/.changeset/bright-ravens-confess.md
@@ -1,0 +1,5 @@
+---
+'@supabase/ssr': minor
+---
+
+Improves the cookie chunker in @supabase/ssr to get rid of edge cases in saving and removing cookies.

--- a/packages/ssr/src/utils/chunker.ts
+++ b/packages/ssr/src/utils/chunker.ts
@@ -99,7 +99,6 @@ export async function deleteChunks(
 
 	if (value) {
 		await removeChunk(key);
-		return;
 	}
 
 	for (let i = 0; ; i++) {


### PR DESCRIPTION
Fixes/improves some edge cases in the cookie chunker for `ssr`:

1. `deleteChunks` now attempts to delete both the key and potential leftover chunks, instead of deleting the first thing it notices. This should decrease the total size of cookies by removing orphaned chunks, and also is a bit safer in situations where leftover chunks are mistaken as the continuation of other chunks.
2. Avoid using parallel cookie setting in `setItem`, and instead do it serially.
3. `setItem` first clears all chunks before setting the new ones.