### PR TITLE
feat: auth-helpers-nextjs total fix with createMiddlewareClientV2

### DIFF
--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -3,7 +3,7 @@ export type { Session, User, SupabaseClient } from '@supabase/supabase-js';
 
 export { createPagesBrowserClient } from './pagesBrowserClient';
 export { createPagesServerClient } from './pagesServerClient';
-export { createMiddlewareClient } from './middlewareClient';
+export { createMiddlewareClient, createMiddlewareClientV2 } from './middlewareClient';
 export { createClientComponentClient } from './clientComponentClient';
 export { createServerComponentClient } from './serverComponentClient';
 export { createRouteHandlerClient } from './routeHandlerClient';

--- a/packages/nextjs/src/middlewareClient.ts
+++ b/packages/nextjs/src/middlewareClient.ts
@@ -15,6 +15,9 @@ import type { NextRequest } from 'next/server';
 import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+/**
+ * @deprecated Broken implementation, do not use.
+ */
 class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
 	constructor(
 		private readonly context: { req: NextRequest; res: NextResponse },
@@ -60,6 +63,11 @@ class NextMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
 	}
 }
 
+/**
+ * @deprecated Use {@link #createMiddlewareClientV2}. This function has a broken
+ * implementation which can cause issues with maintaining the session for a
+ * user for longer periods of time.
+ */
 export function createMiddlewareClient<
 	Database = any,
 	SchemaName extends string & keyof Database = 'public' extends keyof Database
@@ -101,4 +109,229 @@ export function createMiddlewareClient<
 			storage: new NextMiddlewareAuthStorageAdapter(context, cookieOptions)
 		}
 	});
+}
+
+class RequestCookiesAuthStorageAdapter extends CookieAuthStorageAdapter {
+	items: { [name: string]: string } = {};
+	deleteItems: { [name: string]: boolean } = {};
+
+	private res: NextResponse | null = null;
+
+	constructor(private readonly req: NextRequest, cookieOptions?: CookieOptionsWithName) {
+		super(cookieOptions);
+	}
+
+	async getItem(key: string): Promise<string | null> {
+		if (this.items[key]) {
+			return this.items[key];
+		}
+
+		const item = await super.getItem(key);
+
+		if (item) {
+			this.items[key] = item;
+			delete this.deleteItems[key];
+		}
+
+		return item;
+	}
+
+	async setItem(key: string, value: string): Promise<void> {
+		// note how this does not call super.setItem
+		// this is intentional, as that implementation is used from commitCookies
+
+		this.items[key] = value;
+		delete this.deleteItems[key];
+	}
+
+	async removeItem(key: string): Promise<void> {
+		// note how this does not call super.removeItem
+		// this is intentional, as that implementation is used from commitCookies
+
+		delete this.items[key];
+		this.deleteItems[key] = true;
+	}
+
+	commitCookies(res: NextResponse) {
+		try {
+			this.res = res;
+
+			const supRemoveItem = super.removeItem.bind(this);
+			const supSetItem = super.setItem.bind(this);
+
+			Object.keys(this.deleteItems).forEach((name) => {
+				supRemoveItem(name);
+			});
+
+			Object.entries(this.items).forEach(([name, value]) => {
+				supSetItem(name, value);
+			});
+		} finally {
+			this.res = null;
+		}
+	}
+
+	/**
+	 * Only used initially from {@link #getItem}.
+	 */
+	protected getCookie(name: string): string | null | undefined {
+		const cookies = parseCookies(this.req.headers.get('cookie') ?? '');
+		return cookies[name];
+	}
+
+	/**
+	 * Only called from {@link #commitCookies}.
+	 */
+	protected setCookie(name: string, value: string): void {
+		return this._setCookie(name, value);
+	}
+
+	/**
+	 * Only called from {@link #commitCookies}.
+	 */
+	protected deleteCookie(name: string): void {
+		this._setCookie(name, '', {
+			maxAge: 0
+		});
+	}
+
+	private _setCookie(name: string, value: string, options?: DefaultCookieOptions): void {
+		const newSessionStr = serializeCookie(name, value, {
+			...this.cookieOptions,
+			...options,
+			// Allow supabase-js on the client to read the cookie as well
+			httpOnly: false
+		});
+
+		if (this.res?.headers) {
+			this.res.headers.append('set-cookie', newSessionStr);
+		}
+	}
+}
+
+/**
+ * Returns an array of SupabaseClient and a function that when called produces
+ * the {@link NextResponse#next()} response to be returned in the NextJS
+ * middleware function.
+ *
+ * You must call this function towards the end of your middleware function,
+ * typically as part of the return statement. Failing to return the result from
+ * this function can result in your users being randomly logged out.
+ *
+ * @example Here's a basic example:
+ * ```
+ * export function middleware(request: NextRequest) {
+ *   const [supabaseClient, nextResponse] = createMiddlewareClientV2(request, {})
+ *
+ *   const { data: { user } } = await supabaseClient.auth.getUser()
+ *
+ *   if (!user) {
+ *     // there's no user session, ask them to log in
+ *     return NextResponse.redirect(new URL('/sign-in-page-in-your-app'))
+ *   }
+ *
+ *   return nextResponse()
+ * }
+ * ```
+ */
+export function createMiddlewareClientV2<
+	Database = any,
+	SchemaName extends string & keyof Database = 'public' extends keyof Database
+		? 'public'
+		: string & keyof Database,
+	Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+		? Database[SchemaName]
+		: any
+>(
+	req: NextRequest,
+	{
+		supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+		supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+		options,
+		cookieOptions
+	}: {
+		supabaseUrl?: string;
+		supabaseKey?: string;
+		options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+		cookieOptions?: CookieOptionsWithName;
+	} = {}
+) {
+	if (!supabaseUrl || !supabaseKey) {
+		throw new Error(
+			'either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!'
+		);
+	}
+
+	const storage = new RequestCookiesAuthStorageAdapter(req, cookieOptions);
+
+	const client = createSupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, {
+		...options,
+		global: {
+			...options?.global,
+			headers: {
+				...options?.global?.headers,
+				'X-Client-Info': `${PACKAGE_NAME}@${PACKAGE_VERSION}`
+			}
+		},
+		auth: {
+			storage
+		}
+	});
+
+	const responseFn: () => NextResponse = () => {
+		const requestCookies = (req.headers.get('cookie') || '')
+			.split(/\s*;\s*/g)
+			.map((part) => part.split(/=/g))
+			.reduce((a, [name, value]) => {
+				a[name] = value;
+				return a;
+			}, {} as { [cookie: string]: string });
+
+		const removeKeys = {
+			...storage.deleteItems,
+			...storage.items
+		};
+
+		// remove the cookies and their chunks that the client decided
+		// needed removing or setting
+		Object.keys(removeKeys).forEach((key) => {
+			delete requestCookies[key];
+
+			const chunkNames = Object.keys(requestCookies).filter(
+				(k) => k.startsWith(key) && k.length > key.length + 1 && k[key.length] === '.'
+			);
+
+			chunkNames.forEach((chunk) => {
+				delete requestCookies[chunk];
+			});
+		});
+
+		// after the cookies and their chunks have been cleaned up, we
+		// can assign the set items directly; no chunking is needed as
+		// these values will be passed down to the NextJS component /
+		// page / route
+		Object.keys(storage.items).forEach((key) => {
+			requestCookies[key] = storage.items[key];
+		});
+
+		// reconstitute the cookie header on the request
+		req.headers.set(
+			'cookie',
+			Object.entries(requestCookies)
+				.map(([key, value]) => `${key}=${value}`)
+				.join('; ')
+		);
+
+		const response = NextResponse.next({
+			request: req
+		});
+
+		// finally commit the set values as Set-Cookie headers on the
+		// actual response, so the browser can sync up state
+		storage.commitCookies(response);
+
+		return response;
+	};
+
+	return [client, responseFn];
 }


### PR DESCRIPTION
`createMiddlewareClient` was basically completely broken for correctly syncing the session state between the server and browser parts of a NextJS application.

It works in most situations where the user is actively interacting with the site, but as soon as they leave the site for an extended period of time and come back, it's very likely that after the JWT expiry time they will receive an [Invalid Refresh Token](https://supabase.com/docs/guides/auth/sessions#what-is-refresh-token-reuse-detection-and-what-does-it-protect-from) error from the server. Because these events are not time-correlated, it's impossible to debug what is causing them.

Why does this happen:

1. [`NextResponse.next()`](https://nextjs.org/docs/app/api-reference/functions/next-response#next) is not enough. Pages, server-rendered components and route handlers do not see the `Set-Cookie` header set on the *response*.
2. Because this runs in the `middleware.ts` file, the session is correctly refreshed in the middleware client and the `Set-Cookie` headers are set on the response so the browser syncs up with the state *of the middleware client.*
3. However, the page or component client rendered on the server still only sees the `cookie` header from the **request** which is the old session and any use of `getSession()` or `getUser()` will refresh the session *every time.* If you have, say, 3 Data API calls to PostgREST, it's very likely that the session would be refreshed 3 times.
4. Because the page or component cannot set headers on the response, these refreshed sessions just remain unused, but the Auth server already tracks them as the "later" refresh tokens for the user session and is expecting (for security reasons) the browser to know about them too.
5. One hour after this has happened, the Supabase client on browser or server will try to refresh the session from step 2 (coming from `middleware.ts`) and be greeted with the "Invalid Refresh Token" error.

How is this being fixed:

The design of `createMiddlewareClient` does not care at all about what happens to the request, but this is incredibly important so the new refreshed session is passed down to the page or server-rendered component. Furthermore, this cannot "just be set" as for the propagation to take place, `NextResponse.next({ request })` needs to be called.

Therefore, `createMiddlewareClient` is fully deprecated and replaced with its new counterpart `createMiddlewareClient2`. This works a bit differently (without reinventing the simplistic beauty of the `@supabase/ssr` package):

```typescript
export function middleware(request: NextRequest) {
  const [supabaseClient, nextResponse] = createMiddlewareClient2(request, { /* standard client options */ })

  const { data: { user } } = await supabaseClient.auth.getUser()

  if (!user) {
    // there's no user session, ask them to log in
    return NextResponse.redirect(new URL('/sign-in-page-in-your-app'))
  }

  return nextResponse()
}
```

Firstly it returns two arguments, the Supabase client and a `nextResponse` function. It should be called towards the bottom of the `middleware.ts` file, ideally in the `return` statement.

The client is setup such that, it initially reads from the request's `Cookie` header, but writes the changes to local memory. It tracks what **items** (not cookies!) are being set or deleted.

When you call `nextResponse()` the requests's `Cookie` header is reset to reflect the new state of the Supabase client. Because this header will just be propagated down to the page or server-rendered component, no cookie chunking is necessary.

Then, it calls:

```typescript
NextResponse.next({
  request
})
```

Which ensures that the request's changes will be actually propagated down to the page or component. This enables the clients there to pick up the `Cookie` header which now includes the refreshed session.

Finally, it sets the `Set-Cookie` header on the response, which eventually reaches the browser and the session state is finally synchronized between them.