### PR TITLE
chore(ssr): replace ramda with moderndash, reduce global package size

### DIFF
--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -38,8 +38,7 @@
 		"node": ">=16.15"
 	},
 	"dependencies": {
-		"cookie": "^0.5.0",
-		"moderndash": "^3.11.1"
+		"cookie": "^0.5.0"
 	},
 	"devDependencies": {
 		"@supabase/supabase-js": "2.42.0",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -34,19 +34,22 @@
 		"url": "https://github.com/supabase/auth-helpers/issues"
 	},
 	"homepage": "https://github.com/supabase/auth-helpers#readme",
+	"engines": {
+		"node": ">=16.15"
+	},
 	"dependencies": {
 		"cookie": "^0.5.0",
-		"ramda": "^0.29.0"
+		"moderndash": "^3.11.1"
 	},
 	"devDependencies": {
 		"@supabase/supabase-js": "2.42.0",
 		"@types/cookie": "^0.5.1",
-		"@types/ramda": "^0.29.3",
 		"tsconfig": "workspace:*",
 		"tsup": "^6.7.0",
 		"vitest": "^0.34.6"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.33.1"
+		"@supabase/supabase-js": "^2.33.1",
+		"typescript": ">=4.8"
 	}
 }

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -1,11 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
-import { merge } from 'moderndash';
 import {
 	DEFAULT_COOKIE_OPTIONS,
 	combineChunks,
 	createChunks,
 	deleteChunks,
-	isBrowser
+	isBrowser,
+	merge
 } from './utils';
 import { parse, serialize } from 'cookie';
 

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { mergeDeepRight } from 'ramda';
+import { merge } from 'moderndash';
 import {
 	DEFAULT_COOKIE_OPTIONS,
 	combineChunks,
@@ -157,7 +157,7 @@ export function createBrowserClient<
 	};
 
 	// Overwrites default client config with any user defined options
-	const clientOptions = mergeDeepRight(
+	const clientOptions = merge(
 		cookieClientOptions,
 		userDefinedClientOptions
 	) as SupabaseClientOptions<SchemaName>;

--- a/packages/ssr/src/createServerClient.ts
+++ b/packages/ssr/src/createServerClient.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { mergeDeepRight } from 'ramda';
+import { merge } from 'moderndash';
 import {
 	DEFAULT_COOKIE_OPTIONS,
 	combineChunks,
@@ -121,7 +121,7 @@ export function createServerClient<
 	};
 
 	// Overwrites default client config with any user defined options
-	const clientOptions = mergeDeepRight(
+	const clientOptions = merge(
 		cookieClientOptions,
 		userDefinedClientOptions
 	) as SupabaseClientOptions<SchemaName>;

--- a/packages/ssr/src/createServerClient.ts
+++ b/packages/ssr/src/createServerClient.ts
@@ -1,11 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
-import { merge } from 'moderndash';
 import {
 	DEFAULT_COOKIE_OPTIONS,
 	combineChunks,
 	createChunks,
 	deleteChunks,
-	isBrowser
+	isBrowser,
+	merge
 } from './utils';
 
 import type {

--- a/packages/ssr/src/utils/helpers.ts
+++ b/packages/ssr/src/utils/helpers.ts
@@ -3,3 +3,18 @@ export { parse, serialize } from 'cookie';
 export function isBrowser() {
 	return typeof window !== 'undefined' && typeof window.document !== 'undefined';
 }
+
+// This function is copied and adapted from ModernDash by Maximilian Dewald under the MIT License.
+// Source: https://github.com/Maggi64/moderndash/blob/main/package/src/object/merge.ts#L28-L38
+export function merge(target: Record<any, any>, ...sources: Record<any, any>[]) {
+	const targetCopy = { ...target };
+	for (const source of sources) {
+		for (const [key, value] of Object.entries(source)) {
+			targetCopy[key] =
+				value?.constructor === Object && targetCopy[key]?.constructor === Object
+					? merge(targetCopy[key], value)
+					: value;
+		}
+	}
+	return targetCopy;
+}

--- a/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
+++ b/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
@@ -35,20 +35,23 @@ var package_default = {
     url: "https://github.com/supabase/auth-helpers/issues"
   },
   homepage: "https://github.com/supabase/auth-helpers#readme",
+  engines: {
+		node: ">=16.15"
+	},
   dependencies: {
     cookie: "^0.5.0",
-    ramda: "^0.29.0"
+		moderndash: "^3.11.1"
   },
   devDependencies: {
     "@supabase/supabase-js": "2.33.1",
     "@types/cookie": "^0.5.1",
-    "@types/ramda": "^0.29.3",
     tsconfig: "workspace:*",
     tsup: "^6.7.0",
     vitest: "^0.34.6"
   },
   peerDependencies: {
-    "@supabase/supabase-js": "^2.33.1"
+    "@supabase/supabase-js": "^2.33.1",
+		typescript: ">=4.8"
   }
 };
 

--- a/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
+++ b/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
@@ -1,79 +1,67 @@
 // package.json
 var package_default = {
-  name: "@supabase/ssr",
-  version: "0.1.0",
-  main: "dist/index.js",
-  module: "dist/index.mjs",
-  types: "dist/index.d.ts",
-  publishConfig: {
-    access: "public"
-  },
-  files: [
-    "dist"
-  ],
-  scripts: {
-    lint: "tsc",
-    build: "tsup",
-    test: "vitest run",
-    "test:watch": "vitest"
-  },
-  repository: {
-    type: "git",
-    url: "git+https://github.com/supabase/auth-helpers.git"
-  },
-  keywords: [
-    "Supabase",
-    "Auth",
-    "Next.js",
-    "Svelte Kit",
-    "Remix",
-    "Express"
-  ],
-  author: "Supabase",
-  license: "MIT",
-  bugs: {
-    url: "https://github.com/supabase/auth-helpers/issues"
-  },
-  homepage: "https://github.com/supabase/auth-helpers#readme",
-  engines: {
-		node: ">=16.15"
+	name: '@supabase/ssr',
+	version: '0.1.0',
+	main: 'dist/index.js',
+	module: 'dist/index.mjs',
+	types: 'dist/index.d.ts',
+	publishConfig: {
+		access: 'public'
 	},
-  dependencies: {
-    cookie: "^0.5.0",
-    moderndash: "^3.11.1"
-  },
-  devDependencies: {
-    "@supabase/supabase-js": "2.33.1",
-    "@types/cookie": "^0.5.1",
-    tsconfig: "workspace:*",
-    tsup: "^6.7.0",
-    vitest: "^0.34.6"
-  },
-  peerDependencies: {
-    "@supabase/supabase-js": "^2.33.1",
-		typescript: ">=4.8"
-  }
+	files: ['dist'],
+	scripts: {
+		lint: 'tsc',
+		build: 'tsup',
+		test: 'vitest run',
+		'test:watch': 'vitest'
+	},
+	repository: {
+		type: 'git',
+		url: 'git+https://github.com/supabase/auth-helpers.git'
+	},
+	keywords: ['Supabase', 'Auth', 'Next.js', 'Svelte Kit', 'Remix', 'Express'],
+	author: 'Supabase',
+	license: 'MIT',
+	bugs: {
+		url: 'https://github.com/supabase/auth-helpers/issues'
+	},
+	homepage: 'https://github.com/supabase/auth-helpers#readme',
+	engines: {
+		node: '>=16.15'
+	},
+	dependencies: {
+		cookie: '^0.5.0'
+	},
+	devDependencies: {
+		'@supabase/supabase-js': '2.33.1',
+		'@types/cookie': '^0.5.1',
+		tsconfig: 'workspace:*',
+		tsup: '^6.7.0',
+		vitest: '^0.34.6'
+	},
+	peerDependencies: {
+		'@supabase/supabase-js': '^2.33.1',
+		typescript: '>=4.8'
+	}
 };
 
 // tsup.config.ts
 var tsup = {
-  dts: true,
-  entryPoints: ["src/index.ts"],
-  external: ["react", "next", /^@supabase\//],
-  format: ["cjs", "esm"],
-  //   inject: ['src/react-shim.js'],
-  // ! .cjs/.mjs doesn't work with Angular's webpack4 config by default!
-  legacyOutput: false,
-  sourcemap: true,
-  splitting: false,
-  bundle: true,
-  clean: true,
-  define: {
-    PACKAGE_NAME: JSON.stringify(package_default.name.replace("@", "").replace("/", "-")),
-    PACKAGE_VERSION: JSON.stringify(package_default.version)
-  }
+	dts: true,
+	entryPoints: ['src/index.ts'],
+	external: ['react', 'next', /^@supabase\//],
+	format: ['cjs', 'esm'],
+	//   inject: ['src/react-shim.js'],
+	// ! .cjs/.mjs doesn't work with Angular's webpack4 config by default!
+	legacyOutput: false,
+	sourcemap: true,
+	splitting: false,
+	bundle: true,
+	clean: true,
+	define: {
+		PACKAGE_NAME: JSON.stringify(package_default.name.replace('@', '').replace('/', '-')),
+		PACKAGE_VERSION: JSON.stringify(package_default.version)
+	}
 };
-export {
-  tsup
-};
+export { tsup };
 //# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsicGFja2FnZS5qc29uIiwgInRzdXAuY29uZmlnLnRzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJ7XG5cdFwibmFtZVwiOiBcIkBzdXBhYmFzZS9zc3JcIixcblx0XCJ2ZXJzaW9uXCI6IFwiMC4xLjBcIixcblx0XCJtYWluXCI6IFwiZGlzdC9pbmRleC5qc1wiLFxuXHRcIm1vZHVsZVwiOiBcImRpc3QvaW5kZXgubWpzXCIsXG5cdFwidHlwZXNcIjogXCJkaXN0L2luZGV4LmQudHNcIixcblx0XCJwdWJsaXNoQ29uZmlnXCI6IHtcblx0XHRcImFjY2Vzc1wiOiBcInB1YmxpY1wiXG5cdH0sXG5cdFwiZmlsZXNcIjogW1xuXHRcdFwiZGlzdFwiXG5cdF0sXG5cdFwic2NyaXB0c1wiOiB7XG5cdFx0XCJsaW50XCI6IFwidHNjXCIsXG5cdFx0XCJidWlsZFwiOiBcInRzdXBcIixcblx0XHRcInRlc3RcIjogXCJ2aXRlc3QgcnVuXCIsXG5cdFx0XCJ0ZXN0OndhdGNoXCI6IFwidml0ZXN0XCJcblx0fSxcblx0XCJyZXBvc2l0b3J5XCI6IHtcblx0XHRcInR5cGVcIjogXCJnaXRcIixcblx0XHRcInVybFwiOiBcImdpdCtodHRwczovL2dpdGh1Yi5jb20vc3VwYWJhc2UvYXV0aC1oZWxwZXJzLmdpdFwiXG5cdH0sXG5cdFwia2V5d29yZHNcIjogW1xuXHRcdFwiU3VwYWJhc2VcIixcblx0XHRcIkF1dGhcIixcblx0XHRcIk5leHQuanNcIixcblx0XHRcIlN2ZWx0ZSBLaXRcIixcblx0XHRcIlJlbWl4XCIsXG5cdFx0XCJFeHByZXNzXCJcblx0XSxcblx0XCJhdXRob3JcIjogXCJTdXBhYmFzZVwiLFxuXHRcImxpY2Vuc2VcIjogXCJNSVRcIixcblx0XCJidWdzXCI6IHtcblx0XHRcInVybFwiOiBcImh0dHBzOi8vZ2l0aHViLmNvbS9zdXBhYmFzZS9hdXRoLWhlbHBlcnMvaXNzdWVzXCJcblx0fSxcblx0XCJob21lcGFnZVwiOiBcImh0dHBzOi8vZ2l0aHViLmNvbS9zdXBhYmFzZS9hdXRoLWhlbHBlcnMjcmVhZG1lXCIsXG5cdFwiZGVwZW5kZW5jaWVzXCI6IHtcblx0XHRcImNvb2tpZVwiOiBcIl4wLjUuMFwiLFxuXHRcdFwicmFtZGFcIjogXCJeMC4yOS4wXCJcblx0fSxcblx0XCJkZXZEZXBlbmRlbmNpZXNcIjoge1xuXHRcdFwiQHN1cGFiYXNlL3N1cGFiYXNlLWpzXCI6IFwiMi4zMy4xXCIsXG5cdFx0XCJAdHlwZXMvY29va2llXCI6IFwiXjAuNS4xXCIsXG5cdFx0XCJAdHlwZXMvcmFtZGFcIjogXCJeMC4yOS4zXCIsXG5cdFx0XCJ0c2NvbmZpZ1wiOiBcIndvcmtzcGFjZToqXCIsXG5cdFx0XCJ0c3VwXCI6IFwiXjYuNy4wXCIsXG5cdFx0XCJ2aXRlc3RcIjogXCJeMC4zNC42XCJcblx0fSxcblx0XCJwZWVyRGVwZW5kZW5jaWVzXCI6IHtcblx0XHRcIkBzdXBhYmFzZS9zdXBhYmFzZS1qc1wiOiBcIl4yLjMzLjFcIlxuXHR9XG59XG4iLCAiY29uc3QgX19pbmplY3RlZF9maWxlbmFtZV9fID0gXCIvVXNlcnMva2FuZ21pbmd0YXkvV29yay9TdXBhYmFzZS9hdXRoLWhlbHBlcnMvcGFja2FnZXMvc3NyL3RzdXAuY29uZmlnLnRzXCI7Y29uc3QgX19pbmplY3RlZF9kaXJuYW1lX18gPSBcIi9Vc2Vycy9rYW5nbWluZ3RheS9Xb3JrL1N1cGFiYXNlL2F1dGgtaGVscGVycy9wYWNrYWdlcy9zc3JcIjtjb25zdCBfX2luamVjdGVkX2ltcG9ydF9tZXRhX3VybF9fID0gXCJmaWxlOi8vL1VzZXJzL2thbmdtaW5ndGF5L1dvcmsvU3VwYWJhc2UvYXV0aC1oZWxwZXJzL3BhY2thZ2VzL3Nzci90c3VwLmNvbmZpZy50c1wiO2ltcG9ydCB0eXBlIHsgT3B0aW9ucyB9IGZyb20gJ3RzdXAnO1xuaW1wb3J0IHBrZyBmcm9tICcuL3BhY2thZ2UuanNvbic7XG5cbmV4cG9ydCBjb25zdCB0c3VwOiBPcHRpb25zID0ge1xuXHRkdHM6IHRydWUsXG5cdGVudHJ5UG9pbnRzOiBbJ3NyYy9pbmRleC50cyddLFxuXHRleHRlcm5hbDogWydyZWFjdCcsICduZXh0JywgL15Ac3VwYWJhc2VcXC8vXSxcblx0Zm9ybWF0OiBbJ2NqcycsICdlc20nXSxcblx0Ly8gICBpbmplY3Q6IFsnc3JjL3JlYWN0LXNoaW0uanMnXSxcblx0Ly8gISAuY2pzLy5tanMgZG9lc24ndCB3b3JrIHdpdGggQW5ndWxhcidzIHdlYnBhY2s0IGNvbmZpZyBieSBkZWZhdWx0IVxuXHRsZWdhY3lPdXRwdXQ6IGZhbHNlLFxuXHRzb3VyY2VtYXA6IHRydWUsXG5cdHNwbGl0dGluZzogZmFsc2UsXG5cdGJ1bmRsZTogdHJ1ZSxcblx0Y2xlYW46IHRydWUsXG5cdGRlZmluZToge1xuXHRcdFBBQ0tBR0VfTkFNRTogSlNPTi5zdHJpbmdpZnkocGtnLm5hbWUucmVwbGFjZSgnQCcsICcnKS5yZXBsYWNlKCcvJywgJy0nKSksXG5cdFx0UEFDS0FHRV9WRVJTSU9OOiBKU09OLnN0cmluZ2lmeShwa2cudmVyc2lvbilcblx0fVxufTtcbiJdLAogICJtYXBwaW5ncyI6ICI7QUFBQTtBQUFBLEVBQ0MsTUFBUTtBQUFBLEVBQ1IsU0FBVztBQUFBLEVBQ1gsTUFBUTtBQUFBLEVBQ1IsUUFBVTtBQUFBLEVBQ1YsT0FBUztBQUFBLEVBQ1QsZUFBaUI7QUFBQSxJQUNoQixRQUFVO0FBQUEsRUFDWDtBQUFBLEVBQ0EsT0FBUztBQUFBLElBQ1I7QUFBQSxFQUNEO0FBQUEsRUFDQSxTQUFXO0FBQUEsSUFDVixNQUFRO0FBQUEsSUFDUixPQUFTO0FBQUEsSUFDVCxNQUFRO0FBQUEsSUFDUixjQUFjO0FBQUEsRUFDZjtBQUFBLEVBQ0EsWUFBYztBQUFBLElBQ2IsTUFBUTtBQUFBLElBQ1IsS0FBTztBQUFBLEVBQ1I7QUFBQSxFQUNBLFVBQVk7QUFBQSxJQUNYO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxFQUNEO0FBQUEsRUFDQSxRQUFVO0FBQUEsRUFDVixTQUFXO0FBQUEsRUFDWCxNQUFRO0FBQUEsSUFDUCxLQUFPO0FBQUEsRUFDUjtBQUFBLEVBQ0EsVUFBWTtBQUFBLEVBQ1osY0FBZ0I7QUFBQSxJQUNmLFFBQVU7QUFBQSxJQUNWLE9BQVM7QUFBQSxFQUNWO0FBQUEsRUFDQSxpQkFBbUI7QUFBQSxJQUNsQix5QkFBeUI7QUFBQSxJQUN6QixpQkFBaUI7QUFBQSxJQUNqQixnQkFBZ0I7QUFBQSxJQUNoQixVQUFZO0FBQUEsSUFDWixNQUFRO0FBQUEsSUFDUixRQUFVO0FBQUEsRUFDWDtBQUFBLEVBQ0Esa0JBQW9CO0FBQUEsSUFDbkIseUJBQXlCO0FBQUEsRUFDMUI7QUFDRDs7O0FDaERPLElBQU0sT0FBZ0I7QUFBQSxFQUM1QixLQUFLO0FBQUEsRUFDTCxhQUFhLENBQUMsY0FBYztBQUFBLEVBQzVCLFVBQVUsQ0FBQyxTQUFTLFFBQVEsY0FBYztBQUFBLEVBQzFDLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQTtBQUFBO0FBQUEsRUFHckIsY0FBYztBQUFBLEVBQ2QsV0FBVztBQUFBLEVBQ1gsV0FBVztBQUFBLEVBQ1gsUUFBUTtBQUFBLEVBQ1IsT0FBTztBQUFBLEVBQ1AsUUFBUTtBQUFBLElBQ1AsY0FBYyxLQUFLLFVBQVUsZ0JBQUksS0FBSyxRQUFRLEtBQUssRUFBRSxFQUFFLFFBQVEsS0FBSyxHQUFHLENBQUM7QUFBQSxJQUN4RSxpQkFBaUIsS0FBSyxVQUFVLGdCQUFJLE9BQU87QUFBQSxFQUM1QztBQUNEOyIsCiAgIm5hbWVzIjogW10KfQo=

--- a/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
+++ b/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
@@ -40,7 +40,7 @@ var package_default = {
 	},
   dependencies: {
     cookie: "^0.5.0",
-		moderndash: "^3.11.1"
+    moderndash: "^3.11.1"
   },
   devDependencies: {
     "@supabase/supabase-js": "2.33.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

The SSR package does not have a lot of dependencies, but one of them is taking the whole place. I tried multiple tools to compare the size, and it looks ``ramda`` is the one having this issue.

I did some search, and the lightest package i found (not deprecated) was [``moderndash``](https://github.com/Maggi64/moderndash), offering around -75% less in terms of size, while still having the same features.

Some requirements are needed tho:
- Node version >= 16.5
- Typescript (if used) => 4.8

## What is the current behavior?

The package is too heavy for the code inside it.

## What is the new behavior?

This change reduces the size of the package. Not sure of how many, but it should reduce the size of 50% at least.

## Additional context

### Bundlephobia

![image](https://github.com/supabase/auth-helpers/assets/25107942/38baff09-c9f9-4893-881b-ab859f931404)

### pkg-size.dev

![image](https://github.com/supabase/auth-helpers/assets/25107942/2e7d9dbd-473f-4774-bdc3-496bb8cce6b1)

### Npmjs

![image](https://github.com/supabase/auth-helpers/assets/25107942/cb3c82e9-ba00-4622-aeef-1fa30f7a4d48)
