### PR TITLE
fix: cookie maxAge should be in seconds

### DIFF
--- a/packages/ssr/src/utils/constants.ts
+++ b/packages/ssr/src/utils/constants.ts
@@ -4,5 +4,5 @@ export const DEFAULT_COOKIE_OPTIONS: CookieOptions = {
 	path: '/',
 	sameSite: 'lax',
 	httpOnly: false,
-	maxAge: 60 * 60 * 24 * 365 * 1000
+	maxAge: 60 * 60 * 24 * 365
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Cookie maxAge is currently being set to 1000 years, since maxAge is specified in seconds, not milliseconds.

## What is the new behavior?

Cookie maxAge is 365 days (1 year), below the maxAge limit of 400 days (https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2)

## Additional context

Sorry for creating #765 again, but I don't think it's being monitored anymore now that it is closed. 

As detailed in the earlier PR, this is seriously affecting usability for us with Hono, as it's currently requiring me to re-patch `@supabase/ssr` every time a new update to the package is released.