### PR TITLE
feat: fix `ssr` cookie handling in all edge cases

### DIFF
--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -35,8 +35,7 @@
 	},
 	"homepage": "https://github.com/supabase/auth-helpers#readme",
 	"dependencies": {
-		"cookie": "^0.5.0",
-		"ramda": "^0.29.0"
+		"cookie": "^0.5.0"
 	},
 	"devDependencies": {
 		"@supabase/supabase-js": "2.42.0",

--- a/packages/ssr/src/common.ts
+++ b/packages/ssr/src/common.ts
@@ -1,0 +1,272 @@
+import { parse, serialize } from 'cookie';
+
+import {
+	DEFAULT_COOKIE_OPTIONS,
+	combineChunks,
+	createChunks,
+	deleteChunks,
+	isBrowser,
+	isChunkLike
+} from './utils';
+
+import type {
+	CookieMethods,
+	CookieMethodsBrowser,
+	CookieOptions,
+	CookieOptionsWithName,
+	GetAllCookies,
+	SetAllCookies
+} from './types';
+
+/**
+ * Creates a storage client that handles cookies correctly for browser and
+ * server clients with or without properly provided cookie methods.
+ */
+export function createStorageFromOptions(
+	options: {
+		cookies?: CookieMethods | CookieMethodsBrowser;
+		cookieOptions?: CookieOptionsWithName;
+	} | null,
+	isServerClient: boolean
+) {
+	const cookies = options?.cookies ?? null;
+
+	const setItems: { [key: string]: string } = {};
+	const removedItems: { [key: string]: boolean } = {};
+
+	let getAll: (keyHints: string[]) => ReturnType<GetAllCookies>;
+	let setAll: SetAllCookies;
+
+	if (cookies) {
+		if ('get' in cookies) {
+			// Just get is not enough, because the client needs to see what cookies are already set and unset them if necessary. To attempt to fix this behavior for most use cases, we pass "hints" which is the keys of the storage items. They are then converted to their corresponding cookie chunk names and are fetched with get. Only 5 chunks are fetched, which should be enough for the majority of use cases, but does not solve those with very large sessions.
+			const getWithHints = async (keyHints: string[]) => {
+				// optimistically find the first 5 potential chunks for the specified key
+				const chunkNames = keyHints.flatMap((keyHint) => [
+					keyHint,
+					...Array.from({ length: 5 }).map((i) => `${keyHint}.${i}`)
+				]);
+
+				const chunks: ReturnType<GetAllCookies> = [];
+
+				for (let i = 0; i < chunkNames.length; i += 1) {
+					const value = await cookies.get(chunkNames[i]);
+
+					if (!value && typeof value !== 'string') {
+						continue;
+					}
+
+					chunks.push({ name: chunkNames[i], value });
+				}
+
+				// TODO: detect and log stale chunks error
+
+				return chunks;
+			};
+
+			getAll = async (keyHints: string[]) => await getWithHints(keyHints);
+
+			if ('set' in cookies && 'remove' in cookies) {
+				setAll = async (setCookies) => {
+					for (let i = 0; i < setCookies.length; i += 1) {
+						const { name, value, options } = setCookies[i];
+
+						if (value) {
+							await cookies.set(name, value, options);
+						} else {
+							await cookies.remove(name);
+						}
+					}
+				};
+			} else if (isServerClient) {
+				setAll = async () => {
+					console.warn(
+						'@supabase/ssr: createServerClient was configured without set and remove cookie methods, but the client needs to set cookies. This can lead to issues such as random logouts, early session termination or increased token refresh requests. If in NextJS, check your middleware.ts file, route handlers and server actions for correctness. Consider switching to the getAll and setAll cookie methods instead of get, set and remove which are deprecated and can be difficult to use correctly.'
+					);
+				};
+			} else {
+				throw new Error(
+					'@supabase/ssr: createBrowserClient requires configuring a getAll and setAll cookie method (deprecated: alternatively both get, set and remove can be used)'
+				);
+			}
+		} else if ('getAll' in cookies) {
+			getAll = async () => await cookies.getAll();
+
+			if ('setAll' in cookies) {
+				setAll = cookies.setAll;
+			} else if (isServerClient) {
+				setAll = async () => {
+					console.warn(
+						'@supabase/ssr: createServerClient was configured without the setAll cookie method, but the client needs to set cookies. This can lead to issues such as random logouts, early session termination or increased token refresh requests. If in NextJS, check your middleware.ts file, route handlers and server actions for correctness.'
+					);
+				};
+			} else {
+				throw new Error(
+					'@supabase/ssr: createBrowserClient requires configuring a getAll and setAll cookie method (deprecated: alternatively both get, set and remove can be used'
+				);
+			}
+		} else {
+			throw new Error(
+				'@supabase/ssr: createBrowserClient must be initialized with cookie options that specify getAll and setAll functions (deprecated: alternatively use get, set and remove)'
+			);
+		}
+	} else if (!isServerClient && isBrowser()) {
+		// The environment is browser, so use the document.cookie API to implement getAll and setAll.
+
+		const noHintGetAll = () => {
+			const parsed = parse(document.cookie);
+
+			return Object.keys(parsed).map((name) => ({ name, value: parsed[name] }));
+		};
+
+		getAll = () => noHintGetAll();
+
+		setAll = (setCookies) => {
+			setCookies.forEach(({ name, value, options }) => {
+				document.cookie = serialize(name, value, options);
+			});
+		};
+	} else if (isServerClient) {
+		throw new Error(
+			'@supabase/ssr: createServerClient must be initialized with cookie options that specify getAll and setAll functions (deprecated, not recommended: alternatively use get, set and remove)'
+		);
+	} else {
+		throw new Error(
+			'@supabase/ssr: createBrowserClient in non-browser runtimes must be initialized with cookie options that specify getAll and setAll functions (deprecated: alternatively use get, set and remove)'
+		);
+	}
+
+	if (!isServerClient) {
+		// This is the storage client to be used in browsers. It only
+		// works on the cookies abstraction, unlike the server client
+		// which only uses cookies to read the initial state. When an
+		// item is set, cookies are both cleared and set to values so
+		// that stale chunks are not left remaining.
+		return {
+			getAll, // for type consistency
+			setAll, // for type consistency
+			setItems, // for type consistency
+			removedItems, // for type consistency
+			storage: {
+				isServer: false,
+				getItem: async (key: string) => {
+					const allCookies = await getAll(key);
+					const chunkedCookie = await combineChunks(key, async (chunkName: string) => {
+						const cookie = allCookies?.find(({ name }) => name === chunkName) || null;
+
+						if (!cookie) {
+							return null;
+						}
+
+						return cookie.value;
+					});
+
+					return chunkedCookie || null;
+				},
+				setItem: async (key: string, value: string) => {
+					const allCookies = await getAll(key);
+					const cookieNames = allCookies?.map(({ name }) => name) || [];
+
+					const removeCookies = new Set(cookieNames.filter((name) => isChunkLike(name, key)));
+
+					const setCookies = createChunks(key, value);
+
+					setCookies.forEach(({ name }) => {
+						removeCookies.delete(name);
+					});
+
+					const removeCookieOptions = {
+						...DEFAULT_COOKIE_OPTIONS,
+						...options?.cookieOptions,
+						maxAge: 0
+					};
+					const setCookieOptions = {
+						...DEFAULT_COOKIE_OPTIONS,
+						...options?.cookieOptions,
+						maxAge: DEFAULT_COOKIE_OPTIONS.maxAge
+					};
+
+					const allToSet = [
+						...[...removeCookies].map((name) => ({
+							name,
+							value: '',
+							options: removeCookieOptions
+						})),
+						...setCookies.map(({ name, value }) => ({ name, value, options: setCookieOptions }))
+					];
+
+					if (allToSet.length > 0) {
+						await setAll(allToSet);
+					}
+				},
+				removeItem: async (key: string) => {
+					const allCookies = await getAll(key);
+					const cookieNames = allCookies?.map(({ name }) => name) || [];
+					const removeCookies = cookieNames.filter((name) => isChunkLike(name, key));
+
+					const removeCookieOptions = {
+						...DEFAULT_COOKIE_OPTIONS,
+						...options?.cookieOptions,
+						maxAge: 0
+					};
+
+					if (removeCookies.length > 0) {
+						await setAll(
+							removeCookies.map((name) => ({ name, value: '', options: removeCookieOptions }))
+						);
+					}
+				}
+			}
+		};
+	}
+
+	// This is the server client. It only uses getAll to read the initial
+	// state. Any subsequent changes to the items is persisted in the
+	// setItems and removedItems objects. createServerClient *must* use
+	// getAll, setAll and the values in setItems and removedItems to
+	// persist the changes *at once* when appropriate (usually only when
+	// the TOKEN_REFRESHED, USER_UPDATED or SIGNED_OUT events are fired by
+	// the Supabase Auth client).
+	return {
+		getAll,
+		setAll,
+		setItems,
+		removedItems,
+		storage: {
+			// to signal to the libraries that these cookies are
+			// coming from a server environment and their value
+			// should not be trusted
+			isServer: true,
+			getItem: async (key: string) => {
+				if (typeof setItems[key] === 'string') {
+					return setItems[key];
+				}
+
+				if (removedItems[key]) {
+					return null;
+				}
+
+				const allCookies = await cookies.getAll();
+				const chunkedCookie = await combineChunks(key, async (chunkName: string) => {
+					const cookie = allCookies?.find(({ name }) => name === chunkName) || null;
+
+					if (!cookie) {
+						return null;
+					}
+
+					return cookie.value;
+				});
+
+				return chunkedCookie || null;
+			},
+			setItem: async (key: string, value: string) => {
+				setItems[key] = value;
+				delete removedItems[key];
+			},
+			removeItem: async (key: string) => {
+				delete setItems[key];
+				removedItems[key] = true;
+			}
+		}
+	};
+}

--- a/packages/ssr/src/createBrowserClient.ts
+++ b/packages/ssr/src/createBrowserClient.ts
@@ -1,11 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
-import { mergeDeepRight } from 'ramda';
 import {
 	DEFAULT_COOKIE_OPTIONS,
 	combineChunks,
 	createChunks,
 	deleteChunks,
-	isBrowser
+	isBrowser,
+	isChunkLike
 } from './utils';
 import { parse, serialize } from 'cookie';
 
@@ -14,7 +14,14 @@ import type {
 	GenericSchema,
 	SupabaseClientOptions
 } from '@supabase/supabase-js/dist/module/lib/types';
-import type { CookieMethods, CookieOptionsWithName } from './types';
+import type {
+	CookieMethodsBrowser,
+	CookieOptions,
+	CookieOptionsWithName,
+	GetAllCookies,
+	SetAllCookies
+} from './types';
+import { createStorageFromOptions } from './common';
 
 let cachedBrowserClient: SupabaseClient<any, string> | undefined;
 
@@ -30,164 +37,46 @@ export function createBrowserClient<
 	supabaseUrl: string,
 	supabaseKey: string,
 	options?: SupabaseClientOptions<SchemaName> & {
-		cookies?: CookieMethods;
+		cookies?: CookieMethodsBrowser;
 		cookieOptions?: CookieOptionsWithName;
 		isSingleton?: boolean;
 	}
 ) {
+	if ((options?.isSingleton || isBrowser()) && cachedBrowserClient) {
+		return cachedBrowserClient;
+	}
+
 	if (!supabaseUrl || !supabaseKey) {
 		throw new Error(
-			`Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
+			`@supabase/ssr: Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
 		);
 	}
 
-	let cookies: CookieMethods = {};
-	let isSingleton = true;
-	let cookieOptions: CookieOptionsWithName | undefined;
-	let userDefinedClientOptions;
+	const { storage } = createStorageFromOptions(options || null, false);
 
-	if (options) {
-		({ cookies = {}, isSingleton = true, cookieOptions, ...userDefinedClientOptions } = options);
-		cookies = cookies || {};
-	}
-
-	if (cookieOptions?.name) {
-		userDefinedClientOptions.auth = {
-			...userDefinedClientOptions.auth,
-			storageKey: cookieOptions.name
-		};
-	}
-
-	const deleteAllChunks = async (key: string) => {
-		await deleteChunks(
-			key,
-			async (chunkName) => {
-				if (typeof cookies.get === 'function') {
-					return await cookies.get(chunkName);
-				}
-				if (isBrowser()) {
-					const documentCookies = parse(document.cookie);
-					return documentCookies[chunkName];
-				}
-			},
-			async (chunkName) => {
-				if (typeof cookies.remove === 'function') {
-					await cookies.remove(chunkName, {
-						...DEFAULT_COOKIE_OPTIONS,
-						...cookieOptions,
-						maxAge: 0
-					});
-				} else {
-					if (isBrowser()) {
-						document.cookie = serialize(chunkName, '', {
-							...DEFAULT_COOKIE_OPTIONS,
-							...cookieOptions,
-							maxAge: 0
-						});
-					}
-				}
-			}
-		);
-	};
-
-	const cookieClientOptions = {
+	const client = createClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, {
+		...options,
 		global: {
+			...options?.global,
 			headers: {
+				...options?.global?.headers,
 				'X-Client-Info': `${PACKAGE_NAME}/${PACKAGE_VERSION}`
 			}
 		},
 		auth: {
+			...(options?.cookieOptions?.name ? { storageKey: options.cookieOptions.name } : null),
+			...options?.auth,
 			flowType: 'pkce',
 			autoRefreshToken: isBrowser(),
 			detectSessionInUrl: isBrowser(),
 			persistSession: true,
-			storage: {
-				// this client is used on the browser so cookies can be trusted
-				isServer: false,
-				getItem: async (key: string) => {
-					const chunkedCookie = await combineChunks(key, async (chunkName) => {
-						if (typeof cookies.get === 'function') {
-							return await cookies.get(chunkName);
-						}
-						if (isBrowser()) {
-							const cookie = parse(document.cookie);
-							return cookie[chunkName];
-						}
-					});
-					return chunkedCookie;
-				},
-				setItem: async (key: string, value: string) => {
-					// first remove all chunks so there is no overlap
-					await deleteAllChunks(key);
-
-					const chunks = await createChunks(key, value);
-
-					for (let i = 0; i < chunks.length; i += 1) {
-						const chunk = chunks[i];
-
-						if (typeof cookies.set === 'function') {
-							await cookies.set(chunk.name, chunk.value, {
-								...DEFAULT_COOKIE_OPTIONS,
-								...cookieOptions,
-								maxAge: DEFAULT_COOKIE_OPTIONS.maxAge
-							});
-						} else {
-							if (isBrowser()) {
-								document.cookie = serialize(chunk.name, chunk.value, {
-									...DEFAULT_COOKIE_OPTIONS,
-									...cookieOptions,
-									maxAge: DEFAULT_COOKIE_OPTIONS.maxAge
-								});
-							}
-						}
-					}
-				},
-				removeItem: async (key: string) => {
-					if (typeof cookies.remove === 'function' && typeof cookies.get !== 'function') {
-						console.log(
-							'Removing chunked cookie without a `get` method is not supported.\n\n\tWhen you call the `createBrowserClient` function from the `@supabase/ssr` package, make sure you declare both a `get` and `remove` method on the `cookies` object.\n\nhttps://supabase.com/docs/guides/auth/server-side/creating-a-client'
-						);
-						return;
-					}
-
-					await deleteAllChunks(key);
-				}
-			}
+			storage
 		}
-	};
+	});
 
-	// Overwrites default client config with any user defined options
-	const clientOptions = mergeDeepRight(
-		cookieClientOptions,
-		userDefinedClientOptions
-	) as SupabaseClientOptions<SchemaName>;
-
-	if (isSingleton) {
-		// The `Singleton` pattern is the default to simplify the instantiation
-		// of a Supabase client in the browser - there must only be one
-
-		const browser = isBrowser();
-
-		if (browser && cachedBrowserClient) {
-			return cachedBrowserClient as SupabaseClient<Database, SchemaName, Schema>;
-		}
-
-		const client = createClient<Database, SchemaName, Schema>(
-			supabaseUrl,
-			supabaseKey,
-			clientOptions
-		);
-
-		if (browser) {
-			// The client should only be cached in the browser
-			cachedBrowserClient = client;
-		}
-
-		return client;
+	if (options?.isSingleton || isBrowser()) {
+		cachedBrowserClient = client;
 	}
 
-	// This allows for multiple Supabase clients, which may be required when using
-	// multiple schemas. The user will be responsible for ensuring a single
-	// instance of Supabase is used for each schema in the browser.
-	return createClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, clientOptions);
+	return client;
 }

--- a/packages/ssr/src/types.ts
+++ b/packages/ssr/src/types.ts
@@ -2,8 +2,77 @@ import type { CookieSerializeOptions } from 'cookie';
 
 export type CookieOptions = Partial<CookieSerializeOptions>;
 export type CookieOptionsWithName = { name?: string } & CookieOptions;
-export type CookieMethods = {
-	get?: (key: string) => Promise<string | null | undefined> | string | null | undefined;
-	set?: (key: string, value: string, options: CookieOptions) => Promise<void> | void;
-	remove?: (key: string, options: CookieOptions) => Promise<void> | void;
-};
+
+export type GetCookie = (
+	name: string
+) => Promise<string | null | undefined> | string | null | undefined;
+
+export type SetCookie = (
+	name: string,
+	value: string,
+	options: CookieOptions
+) => Promise<void> | void;
+export type RemoveCookie = (name: string) => Promise<void> | void;
+
+export type GetAllCookies = () =>
+	| Promise<{ name: string; value: string }[] | null>
+	| { name: string; value: string }[]
+	| null;
+
+export type SetAllCookies = (
+	cookies: { name: string; value: string; options: CookieOptions }[]
+) => Promise<void> | void;
+
+/**
+ * Methods that allow access to cookies in browser-like environments.
+ */
+export type CookieMethodsBrowser =
+	| {
+			/** @deprecated Move to using `getAll` instead. */
+			get: GetCookie;
+			/** @deprecated Move to using `getAll` instead. */
+			set: SetCookie;
+			/** @deprecated Move to using `getAll` instead. */
+			remove: RemoveCookie;
+	  }
+	| { getAll: GetAllCookies; setAll: SetAllCookies };
+
+/**
+ * Methods that allow access to cookies in server-side rendering environments.
+ */
+export type CookieMethods =
+	| {
+			/**
+			 * @deprecated Move to using `getAll` instead.
+			 */
+			get: GetCookie;
+
+			/**
+			 * @deprecated Move to using `setAll` instead.
+			 *
+			 * Optional in certain cases only! Please read the docs on `setAll`.
+			 * */
+			set?: SetCookie;
+
+			/**
+			 * @deprecated Move to using `setAll` instead.
+			 *
+			 * Optional in certain cases only! Please read the docs on `setAll`.
+			 * */
+			remove?: RemoveCookie;
+	  }
+	| {
+			/**
+			 * Returns all cookies associated with the request in which the server-side client is operating. Typically (but not always) this is called only once per request / client instance. In any case, repeated calls of this function should reflect any changes done to cookies if setAll was called.
+			 */
+			getAll: GetAllCookies;
+
+			/**
+			 * Optional in certain cases only! Make sure you implement this method whenever possible, and omit it only in cases where the server-side client is unable to set or manipulate cookies. One common example for this is NextJS server components.
+			 *
+			 * Failing to provide an implementation can result in difficult to debug behavior such as:
+			 * - Random logouts, or early session termination
+			 * - Increased number of API calls on the `.../token?grant_type=refres_token` endpoint
+			 */
+			setAll?: SetAllCookies;
+	  };

--- a/packages/ssr/src/utils/chunker.ts
+++ b/packages/ssr/src/utils/chunker.ts
@@ -5,6 +5,20 @@ interface Chunk {
 
 const MAX_CHUNK_SIZE = 3180;
 
+const CHUNK_LIKE_REGEX = /^(.*)[.](0|[1-9][0-9]*)$/;
+export function isChunkLike(cookieName: string, key: string) {
+	if (cookieName === key) {
+		return true;
+	}
+
+	const chunkLike = cookieName.match(CHUNK_LIKE_REGEX);
+	if (chunkLike && chunkLike[1] === key) {
+		return true;
+	}
+
+	return false;
+}
+
 /**
  * create chunks from a string and return an array of object
  */

--- a/packages/ssr/tests/common.spec.ts
+++ b/packages/ssr/tests/common.spec.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from 'vitest';
+
+import { createStorageFromOptions } from '../src/common';
+
+describe('createStorageFromOptions for createServerClient', () => {
+	describe('storage with getAll, setAll', () => {
+		it('should not call setAll on setItem', async () => {
+			let setAllCalled = false;
+
+			const { storage, setItems, removedItems } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						return [];
+					},
+
+					setAll: async () => {
+						setAllCalled = true;
+					}
+				}
+			});
+
+			await storage.setItem('storage-key', 'value');
+
+			expect(setAllCalled).toBeFalsy();
+			expect(setItems).toEqual({ 'storage-key': 'value' });
+			expect(removedItems).toEqual({});
+		});
+
+		it('should not call setAll on removeItem', async () => {
+			let setAllCalled = false;
+
+			const { storage, setItems, removedItems } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						return [];
+					},
+
+					setAll: async () => {
+						setAllCalled = true;
+					}
+				}
+			});
+
+			await storage.removeItem('storage-key');
+
+			expect(setAllCalled).toBeFalsy();
+			expect(setItems).toEqual({});
+			expect(removedItems).toEqual({ 'storage-key': true });
+		});
+
+		it('should not call getAll if item has already been set', async () => {
+			let getAllCalled = false;
+
+			const { storage } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						getAllCalled = true;
+
+						return [];
+					},
+
+					setAll: async () => {}
+				}
+			});
+
+			await storage.setItem('storage-key', 'value');
+
+			const value = await storage.getItem('storage-key');
+
+			expect(value).toEqual('value');
+			expect(getAllCalled).toBeFalsy();
+		});
+
+		it('should not call getAll if item has already been removed', async () => {
+			let getAllCalled = false;
+
+			const { storage } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						getAllCalled = true;
+
+						return [];
+					},
+
+					setAll: async () => {}
+				}
+			});
+
+			await storage.removeItem('storage-key');
+
+			const value = await storage.getItem('storage-key');
+
+			expect(value).toBeNull();
+			expect(getAllCalled).toBeFalsy();
+		});
+
+		it('should call getAll each time getItem is called until setItem or removeItem', async () => {
+			let getAllCalled = 0;
+
+			const { storage } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						getAllCalled += 1;
+
+						return [];
+					},
+
+					setAll: async () => {}
+				}
+			});
+
+			await storage.getItem('storage-key');
+
+			expect(getAllCalled).toEqual(1);
+
+			await storage.getItem('storage-key');
+
+			expect(getAllCalled).toEqual(2);
+
+			await storage.setItem('storage-key', 'value');
+
+			await storage.getItem('storage-key');
+
+			expect(getAllCalled).toEqual(2);
+		});
+
+		it('should return item value from getAll without chunks', async () => {
+			const { storage } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						return [
+							{
+								name: 'storage-key',
+								value: 'value'
+							},
+							{
+								name: 'other-cookie',
+								value: 'other-value'
+							},
+							{
+								name: 'storage-key.0',
+								value: 'leftover-chunk-value'
+							}
+						];
+					},
+
+					setAll: async () => {}
+				}
+			});
+
+			const value = await storage.getItem('storage-key');
+
+			expect(value).toEqual('value');
+		});
+
+		it('should return item value from getAll with chunks', async () => {
+			const { storage } = createStorageFromOptions({
+				cookies: {
+					getAll: async () => {
+						return [
+							{
+								name: 'other-cookie',
+								value: 'other-value'
+							},
+							{
+								name: 'storage-key.0',
+								value: 'val'
+							},
+							{
+								name: 'storage-key.1',
+								value: 'ue'
+							},
+							{
+								name: 'storage-key.2',
+								value: ''
+							},
+							{
+								name: 'storage-key.3',
+								value: 'leftover-chunk-value'
+							}
+						];
+					},
+
+					setAll: async () => {}
+				}
+			});
+
+			const value = await storage.getItem('storage-key');
+
+			expect(value).toEqual('value');
+		});
+	});
+
+	describe('storage with get, set, remove', () => {
+		it('should call get multiple times for the storage key and its chunks', async () => {
+			const getNames: string[] = [];
+
+			const { storage } = createStorageFromOptions(
+				{
+					get: async (name: string) => {
+						getNames.push(name);
+
+						if (name === 'storage-key') {
+							return 'value';
+						}
+
+						return null;
+					},
+					set: async () => {},
+					remove: async () => {}
+				},
+				true
+			);
+
+			const value = await storage.getItem('storage-key');
+
+			expect(value).toEqual('value');
+
+			expect(getNames).toEqual([
+				'storage-key',
+				'storage-key.0',
+				'storage-key.1',
+				'storage-key.2',
+				'storage-key.3',
+				'storage-key.4'
+			]);
+		});
+
+		it('should reconstruct storage value from chunks', async () => {
+			const { storage } = createStorageFromOptions(
+				{
+					get: async (name: string) => {
+						if (name === 'storage-key.0') {
+							return 'val';
+						}
+
+						if (name === 'storage-key.1') {
+							return 'ue';
+						}
+
+						if (name === 'storage-key.3') {
+							return 'leftover-chunk-value';
+						}
+
+						return null;
+					},
+					set: async () => {},
+					remove: async () => {}
+				},
+				true
+			);
+
+			const value = await storage.getItem('storage-key');
+
+			expect(value).toEqual('value');
+		});
+	});
+
+	describe('setAll when using set, remove', () => {
+		it('should call set and remove depending on the values sent to setAll', async () => {
+			const setCalls: { name: string; value: string }[] = [];
+			const removeCalls: string[] = [];
+
+			const { setAll } = createStorageFromOptions(
+				{
+					get: async (name: string) => {
+						return null;
+					},
+					set: async (name, value, options) => {
+						setCalls.push({ name, value, options });
+					},
+					remove: async (name) => {
+						removeCalls.push(name);
+					}
+				},
+				true
+			);
+
+			await setAll([
+				{
+					name: 'a',
+					value: 'b',
+					options: { maxAge: 10 }
+				},
+				{
+					name: 'b',
+					value: 'c',
+					options: { maxAge: 10 }
+				},
+				{
+					name: 'c',
+					value: '',
+					options: { maxAge: 0 }
+				}
+			]);
+
+			expect(setCalls).toEqual([
+				{ name: 'a', value: 'b', options: { maxAge: 10 } },
+				{ name: 'b', value: 'c', options: { maxAge: 10 } }
+			]);
+
+			expect(removeCalls).toEqual('c');
+		});
+	});
+});
+
+describe('createStorageFromOptions for createBrowserClient', () => {
+	describe('storage', () => {});
+});

--- a/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
+++ b/packages/ssr/tsup.config.bundled_i6zwd190p1m.mjs
@@ -1,76 +1,65 @@
 // package.json
 var package_default = {
-  name: "@supabase/ssr",
-  version: "0.1.0",
-  main: "dist/index.js",
-  module: "dist/index.mjs",
-  types: "dist/index.d.ts",
-  publishConfig: {
-    access: "public"
-  },
-  files: [
-    "dist"
-  ],
-  scripts: {
-    lint: "tsc",
-    build: "tsup",
-    test: "vitest run",
-    "test:watch": "vitest"
-  },
-  repository: {
-    type: "git",
-    url: "git+https://github.com/supabase/auth-helpers.git"
-  },
-  keywords: [
-    "Supabase",
-    "Auth",
-    "Next.js",
-    "Svelte Kit",
-    "Remix",
-    "Express"
-  ],
-  author: "Supabase",
-  license: "MIT",
-  bugs: {
-    url: "https://github.com/supabase/auth-helpers/issues"
-  },
-  homepage: "https://github.com/supabase/auth-helpers#readme",
-  dependencies: {
-    cookie: "^0.5.0",
-    ramda: "^0.29.0"
-  },
-  devDependencies: {
-    "@supabase/supabase-js": "2.33.1",
-    "@types/cookie": "^0.5.1",
-    "@types/ramda": "^0.29.3",
-    tsconfig: "workspace:*",
-    tsup: "^6.7.0",
-    vitest: "^0.34.6"
-  },
-  peerDependencies: {
-    "@supabase/supabase-js": "^2.33.1"
-  }
+	name: '@supabase/ssr',
+	version: '0.1.0',
+	main: 'dist/index.js',
+	module: 'dist/index.mjs',
+	types: 'dist/index.d.ts',
+	publishConfig: {
+		access: 'public'
+	},
+	files: ['dist'],
+	scripts: {
+		lint: 'tsc',
+		build: 'tsup',
+		test: 'vitest run',
+		'test:watch': 'vitest'
+	},
+	repository: {
+		type: 'git',
+		url: 'git+https://github.com/supabase/auth-helpers.git'
+	},
+	keywords: ['Supabase', 'Auth', 'Next.js', 'Svelte Kit', 'Remix', 'Express'],
+	author: 'Supabase',
+	license: 'MIT',
+	bugs: {
+		url: 'https://github.com/supabase/auth-helpers/issues'
+	},
+	homepage: 'https://github.com/supabase/auth-helpers#readme',
+	dependencies: {
+		cookie: '^0.5.0',
+		ramda: '^0.29.0'
+	},
+	devDependencies: {
+		'@supabase/supabase-js': '2.33.1',
+		'@types/cookie': '^0.5.1',
+		'@types/ramda': '^0.29.3',
+		tsconfig: 'workspace:*',
+		tsup: '^6.7.0',
+		vitest: '^0.34.6'
+	},
+	peerDependencies: {
+		'@supabase/supabase-js': '^2.33.1'
+	}
 };
 
 // tsup.config.ts
 var tsup = {
-  dts: true,
-  entryPoints: ["src/index.ts"],
-  external: ["react", "next", /^@supabase\//],
-  format: ["cjs", "esm"],
-  //   inject: ['src/react-shim.js'],
-  // ! .cjs/.mjs doesn't work with Angular's webpack4 config by default!
-  legacyOutput: false,
-  sourcemap: true,
-  splitting: false,
-  bundle: true,
-  clean: true,
-  define: {
-    PACKAGE_NAME: JSON.stringify(package_default.name.replace("@", "").replace("/", "-")),
-    PACKAGE_VERSION: JSON.stringify(package_default.version)
-  }
+	dts: true,
+	entryPoints: ['src/index.ts'],
+	external: ['react', 'next', /^@supabase\//],
+	format: ['cjs', 'esm'],
+	//   inject: ['src/react-shim.js'],
+	// ! .cjs/.mjs doesn't work with Angular's webpack4 config by default!
+	legacyOutput: false,
+	sourcemap: true,
+	splitting: false,
+	bundle: true,
+	clean: true,
+	define: {
+		PACKAGE_NAME: JSON.stringify(package_default.name.replace('@', '').replace('/', '-')),
+		PACKAGE_VERSION: JSON.stringify(package_default.version)
+	}
 };
-export {
-  tsup
-};
+export { tsup };
 //# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsicGFja2FnZS5qc29uIiwgInRzdXAuY29uZmlnLnRzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJ7XG5cdFwibmFtZVwiOiBcIkBzdXBhYmFzZS9zc3JcIixcblx0XCJ2ZXJzaW9uXCI6IFwiMC4xLjBcIixcblx0XCJtYWluXCI6IFwiZGlzdC9pbmRleC5qc1wiLFxuXHRcIm1vZHVsZVwiOiBcImRpc3QvaW5kZXgubWpzXCIsXG5cdFwidHlwZXNcIjogXCJkaXN0L2luZGV4LmQudHNcIixcblx0XCJwdWJsaXNoQ29uZmlnXCI6IHtcblx0XHRcImFjY2Vzc1wiOiBcInB1YmxpY1wiXG5cdH0sXG5cdFwiZmlsZXNcIjogW1xuXHRcdFwiZGlzdFwiXG5cdF0sXG5cdFwic2NyaXB0c1wiOiB7XG5cdFx0XCJsaW50XCI6IFwidHNjXCIsXG5cdFx0XCJidWlsZFwiOiBcInRzdXBcIixcblx0XHRcInRlc3RcIjogXCJ2aXRlc3QgcnVuXCIsXG5cdFx0XCJ0ZXN0OndhdGNoXCI6IFwidml0ZXN0XCJcblx0fSxcblx0XCJyZXBvc2l0b3J5XCI6IHtcblx0XHRcInR5cGVcIjogXCJnaXRcIixcblx0XHRcInVybFwiOiBcImdpdCtodHRwczovL2dpdGh1Yi5jb20vc3VwYWJhc2UvYXV0aC1oZWxwZXJzLmdpdFwiXG5cdH0sXG5cdFwia2V5d29yZHNcIjogW1xuXHRcdFwiU3VwYWJhc2VcIixcblx0XHRcIkF1dGhcIixcblx0XHRcIk5leHQuanNcIixcblx0XHRcIlN2ZWx0ZSBLaXRcIixcblx0XHRcIlJlbWl4XCIsXG5cdFx0XCJFeHByZXNzXCJcblx0XSxcblx0XCJhdXRob3JcIjogXCJTdXBhYmFzZVwiLFxuXHRcImxpY2Vuc2VcIjogXCJNSVRcIixcblx0XCJidWdzXCI6IHtcblx0XHRcInVybFwiOiBcImh0dHBzOi8vZ2l0aHViLmNvbS9zdXBhYmFzZS9hdXRoLWhlbHBlcnMvaXNzdWVzXCJcblx0fSxcblx0XCJob21lcGFnZVwiOiBcImh0dHBzOi8vZ2l0aHViLmNvbS9zdXBhYmFzZS9hdXRoLWhlbHBlcnMjcmVhZG1lXCIsXG5cdFwiZGVwZW5kZW5jaWVzXCI6IHtcblx0XHRcImNvb2tpZVwiOiBcIl4wLjUuMFwiLFxuXHRcdFwicmFtZGFcIjogXCJeMC4yOS4wXCJcblx0fSxcblx0XCJkZXZEZXBlbmRlbmNpZXNcIjoge1xuXHRcdFwiQHN1cGFiYXNlL3N1cGFiYXNlLWpzXCI6IFwiMi4zMy4xXCIsXG5cdFx0XCJAdHlwZXMvY29va2llXCI6IFwiXjAuNS4xXCIsXG5cdFx0XCJAdHlwZXMvcmFtZGFcIjogXCJeMC4yOS4zXCIsXG5cdFx0XCJ0c2NvbmZpZ1wiOiBcIndvcmtzcGFjZToqXCIsXG5cdFx0XCJ0c3VwXCI6IFwiXjYuNy4wXCIsXG5cdFx0XCJ2aXRlc3RcIjogXCJeMC4zNC42XCJcblx0fSxcblx0XCJwZWVyRGVwZW5kZW5jaWVzXCI6IHtcblx0XHRcIkBzdXBhYmFzZS9zdXBhYmFzZS1qc1wiOiBcIl4yLjMzLjFcIlxuXHR9XG59XG4iLCAiY29uc3QgX19pbmplY3RlZF9maWxlbmFtZV9fID0gXCIvVXNlcnMva2FuZ21pbmd0YXkvV29yay9TdXBhYmFzZS9hdXRoLWhlbHBlcnMvcGFja2FnZXMvc3NyL3RzdXAuY29uZmlnLnRzXCI7Y29uc3QgX19pbmplY3RlZF9kaXJuYW1lX18gPSBcIi9Vc2Vycy9rYW5nbWluZ3RheS9Xb3JrL1N1cGFiYXNlL2F1dGgtaGVscGVycy9wYWNrYWdlcy9zc3JcIjtjb25zdCBfX2luamVjdGVkX2ltcG9ydF9tZXRhX3VybF9fID0gXCJmaWxlOi8vL1VzZXJzL2thbmdtaW5ndGF5L1dvcmsvU3VwYWJhc2UvYXV0aC1oZWxwZXJzL3BhY2thZ2VzL3Nzci90c3VwLmNvbmZpZy50c1wiO2ltcG9ydCB0eXBlIHsgT3B0aW9ucyB9IGZyb20gJ3RzdXAnO1xuaW1wb3J0IHBrZyBmcm9tICcuL3BhY2thZ2UuanNvbic7XG5cbmV4cG9ydCBjb25zdCB0c3VwOiBPcHRpb25zID0ge1xuXHRkdHM6IHRydWUsXG5cdGVudHJ5UG9pbnRzOiBbJ3NyYy9pbmRleC50cyddLFxuXHRleHRlcm5hbDogWydyZWFjdCcsICduZXh0JywgL15Ac3VwYWJhc2VcXC8vXSxcblx0Zm9ybWF0OiBbJ2NqcycsICdlc20nXSxcblx0Ly8gICBpbmplY3Q6IFsnc3JjL3JlYWN0LXNoaW0uanMnXSxcblx0Ly8gISAuY2pzLy5tanMgZG9lc24ndCB3b3JrIHdpdGggQW5ndWxhcidzIHdlYnBhY2s0IGNvbmZpZyBieSBkZWZhdWx0IVxuXHRsZWdhY3lPdXRwdXQ6IGZhbHNlLFxuXHRzb3VyY2VtYXA6IHRydWUsXG5cdHNwbGl0dGluZzogZmFsc2UsXG5cdGJ1bmRsZTogdHJ1ZSxcblx0Y2xlYW46IHRydWUsXG5cdGRlZmluZToge1xuXHRcdFBBQ0tBR0VfTkFNRTogSlNPTi5zdHJpbmdpZnkocGtnLm5hbWUucmVwbGFjZSgnQCcsICcnKS5yZXBsYWNlKCcvJywgJy0nKSksXG5cdFx0UEFDS0FHRV9WRVJTSU9OOiBKU09OLnN0cmluZ2lmeShwa2cudmVyc2lvbilcblx0fVxufTtcbiJdLAogICJtYXBwaW5ncyI6ICI7QUFBQTtBQUFBLEVBQ0MsTUFBUTtBQUFBLEVBQ1IsU0FBVztBQUFBLEVBQ1gsTUFBUTtBQUFBLEVBQ1IsUUFBVTtBQUFBLEVBQ1YsT0FBUztBQUFBLEVBQ1QsZUFBaUI7QUFBQSxJQUNoQixRQUFVO0FBQUEsRUFDWDtBQUFBLEVBQ0EsT0FBUztBQUFBLElBQ1I7QUFBQSxFQUNEO0FBQUEsRUFDQSxTQUFXO0FBQUEsSUFDVixNQUFRO0FBQUEsSUFDUixPQUFTO0FBQUEsSUFDVCxNQUFRO0FBQUEsSUFDUixjQUFjO0FBQUEsRUFDZjtBQUFBLEVBQ0EsWUFBYztBQUFBLElBQ2IsTUFBUTtBQUFBLElBQ1IsS0FBTztBQUFBLEVBQ1I7QUFBQSxFQUNBLFVBQVk7QUFBQSxJQUNYO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxFQUNEO0FBQUEsRUFDQSxRQUFVO0FBQUEsRUFDVixTQUFXO0FBQUEsRUFDWCxNQUFRO0FBQUEsSUFDUCxLQUFPO0FBQUEsRUFDUjtBQUFBLEVBQ0EsVUFBWTtBQUFBLEVBQ1osY0FBZ0I7QUFBQSxJQUNmLFFBQVU7QUFBQSxJQUNWLE9BQVM7QUFBQSxFQUNWO0FBQUEsRUFDQSxpQkFBbUI7QUFBQSxJQUNsQix5QkFBeUI7QUFBQSxJQUN6QixpQkFBaUI7QUFBQSxJQUNqQixnQkFBZ0I7QUFBQSxJQUNoQixVQUFZO0FBQUEsSUFDWixNQUFRO0FBQUEsSUFDUixRQUFVO0FBQUEsRUFDWDtBQUFBLEVBQ0Esa0JBQW9CO0FBQUEsSUFDbkIseUJBQXlCO0FBQUEsRUFDMUI7QUFDRDs7O0FDaERPLElBQU0sT0FBZ0I7QUFBQSxFQUM1QixLQUFLO0FBQUEsRUFDTCxhQUFhLENBQUMsY0FBYztBQUFBLEVBQzVCLFVBQVUsQ0FBQyxTQUFTLFFBQVEsY0FBYztBQUFBLEVBQzFDLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQTtBQUFBO0FBQUEsRUFHckIsY0FBYztBQUFBLEVBQ2QsV0FBVztBQUFBLEVBQ1gsV0FBVztBQUFBLEVBQ1gsUUFBUTtBQUFBLEVBQ1IsT0FBTztBQUFBLEVBQ1AsUUFBUTtBQUFBLElBQ1AsY0FBYyxLQUFLLFVBQVUsZ0JBQUksS0FBSyxRQUFRLEtBQUssRUFBRSxFQUFFLFFBQVEsS0FBSyxHQUFHLENBQUM7QUFBQSxJQUN4RSxpQkFBaUIsS0FBSyxVQUFVLGdCQUFJLE9BQU87QUFBQSxFQUM1QztBQUNEOyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
Fixes many issues with `@supabase/ssr` when handling edge-cases for reading and setting cookies especially in NextJS.

Some of these edge-cases are as follows:

### There's no such thing as removing a cookie.

When cookies are "touched" by the Supabase client, they're either set to a non-empty value or they need to be set to an empty value. When set to an empty value, the `max-age` property must be set to 0 so the browser receiving the `Set-Cookie` header knows to *delete it from its store.*

For example, this [delete](https://nextjs.org/docs/app/api-reference/functions/next-response#deletename) method does not _remove the cookie from the response_ but it just removes the `Set-Cookie` header that would have been sent. But that's not what's wanted -- the Supabase client <ins>**wants to send a `Set-Cookie` header**</ins>. It's therefore not very useful and should not be used.

### Because storage items are often chunked into multiple cookies, <ins>existing cookie chunks must be managed.</ins>

There are 4 cases that need to be dealt with.

1. _Non-chunked to chunked._ (Currently broken.)  
Suppose the storage item with key `xyz` is below the cookie chunk limit, so it's encoded as one cookie under the name `xyz`. But in the session refresh step, the storage item has grown above the cookie chunk limit, so it now needs to be chunked into 2 cookies `xyz.0` and `xyz.1`. In this case, the `xyz` cookie **must be set to `''` and `max-age` to 0** so it's removed from the browser cookie store.
2. _Fewer chunks to more chunks._ (Currently OK.)  
Suppose the storage item with key `xyz` is encoded as two cookie chunks `xyz.0` and `xyz.1`. After the session refresh step, its size has grown and 3 cookie chunks are needed `xyz.0`, `xyz.1` and `xyz.2`. Obviously the first two chunks need to be set to a value and in case they were set to `max-age` 0 now need to be set to the indefinite `max-age`.
3. _More chunks to fewer chunks._ (Currently broken.)  
Suppose the storage item with key `xyz` is encoded as three cookie chunks `xyz.0` through `.2`. After the session refresh step, the size has shrunk down to only need `xyz.0` and `xyz.1`. This means that chunk `xyz.2` needs to be set to `''` value and `max-age` of 0.
4. _Chunked to non-chunked._ (Currently broken.)  
Suppose the storage item with key `xyz` is encoded as two cookie chunks `xyz.0` and `xyz.1`. After the session refresh step, its size has shrunk below the cookie size so it's now encoded as one cookie `xyz`. This means that `xyz.0` and `xyz.1` must be set to `''` and `max-age` of 0.

Because (1), (3) and (4) are not handled properly at this time, they can leave chunk artifacts that float around on every request and can cause *in the future* problems such as:

- `JSON.parse()` failing, for example chunk `xyz.1` ending like `..."` and chunk `xyz.2` starting like `{` (which would fail because a `,` is missing.
- Reading garbage, for example `xyz.1` and `xyz.2` align properly to form fully valid JSON, but with content that is unrecognizable.

### Cookies don't always need to be set (server-side).

There are only 3 situations when cookies should be touched:

1. The session was actually refreshed, i.e. `onAuthStateChange` event with `TOKEN_REFRESHED`.
2. The user object was updated, i.e. `onAuthStateChange` event with `USER_UPDATED`.  
This is because the user object is encoded in the cookies, and the flow server -> browser is *secure.*
3. The user was signed out, most likely because the session refresh identified that the session has ended (user signed out from another device, the session reached its maximum lifetime or inactivity timeout). This is the `SIGNED_OUT` event.

If these events have not occurred on server side, `Set-Cookie` <ins>**must not be present on the response.**</ins> A missing `Set-Cookie` header _tells the browser to obey the cookie store it already has._

### Cookies should be set <ins>in one go</ins> instead of partially (server-side).

The [NextResponse.next()](https://nextjs.org/docs/app/api-reference/functions/next-response#next) API is truly awful in `middleware.ts`. It <ins>**should only be called once**</ins> after all session processing has been completed by the Supabase client.

This is because:

- The <ins>**request**</ins> headers _also contain the cookies._ To propagate the correct cookies down to the server-rendered pages and components, `NextResponse.next({ request: { headers: request.headers } })` **must be called**, but it can only be called after the Supabase client has finished processing the session.
- The **response** headers need to be set on the response object, which from the previous case must be created after the Supabase client has finished processing the session.

So the following pattern, as seen in the Supabase guide for `middleware.ts`:

```typescript
export async function middleware(request: NextRequest) {
  let response = NextResponse.next({
    request: {
      headers: request.headers,
    },
  })

  const supabase = createServerClient(
    process.env.NEXT_PUBLIC_SUPABASE_URL!,
    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
    {
      cookies: {
        get(name: string) {
          return request.cookies.get(name)?.value
        },
        set(name: string, value: string, options: CookieOptions) {
          request.cookies.set({
            name,
            value,
            ...options,
          })
          response = NextResponse.next({
            request: {
              headers: request.headers,
            },
          })
          response.cookies.set({
            name,
            value,
            ...options,
          })
        },
```

Is <ins>**INCORRECT**</ins> because a new response object is created on each cookie set/removal, meaning it **will only contain always only one `Set-Cookie` header** and not the multiple needed to encode chunked cookies or the PKCE state.

## Finally, combining it all together

To solve these multiple issues, this PR modifies the `cookies` option to use a new pattern like so:

```typescript
export async function middleware(request: NextRequest) {
  let response = NextResponse.next({
    request: {
      headers: request.headers,
    },
  })

  const supabase = createServerClient(
    process.env.NEXT_PUBLIC_SUPABASE_URL!,
    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
    {
      cookies: {
        getAll() {
          return request.cookies.getAll()
        },
        setAll(cookies: { name: string, value: string, options: CookieOptions }[]) {
          cookies.forEach(({ name, value, options }) => request.cookies.set({ name, value, ...options }))
 
          response = NextResponse.next({
            request: {
              headers: request.headers,
            },
          })

          cookies.forEach(({ name, value, options }) => response.cookies.set({ name, value, ...options }))
        },
      },
  )

  await supabase.auth.getUser()

  // either the session needed refreshing so `TOKEN_REFRESHED` was called and the `setAll` above was called, 
  // changing the response object; or it wasn't so the original response is being used

  return response
```

Cookies are only set <ins>once</ins> if the `onAuthStateChange` events `TOKEN_REFRESHED`, `USER_UPDATE`, `SIGNED_OUT` were emitted. If these events do not occur, cookies must not be touched, so the initial `response` will be used with the valid cookie chunks.

If cookies need to be set, all the cookie chunks are *managed* properly, so that there are no chunk artifacts floating around. This means the `setAll` call will include both setting `''` on certain cookie names and setting actual values.

### In the browser

The browser client will also use `getAll` and `setAll` similarly, but because this is the browser it's fine to use them directly with the `document.cookie` API -- meaning cookies will always be gotten and set -- **not only on events.**

This is still a WIP.