### PR TITLE
fix: update broken link to the migration doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of framework specific Auth utilities for working with Supabase.
 
 ### Maintenance mode
 
-The Auth helpers package is in maintenance mode and we won’t be actively improving it. We strongly recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+The Auth helpers package is in maintenance mode and we won’t be actively improving it. We strongly recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](https://supabase.com/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 ## Supported Frameworks
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Clicking the current link to the migration docs leads to https://github.com/supabase/auth-helpers/blob/main/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers which is 404 page not found. 

The intended functionality is taking them to https://supabase.com/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers?queryGroups=framework&framework=nextjs

## What is the new behavior?

Links to the correct URL - https://supabase.com/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers
